### PR TITLE
:zap: name space, getTipLabel() read/writeNewick()

### DIFF
--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -26,271 +26,559 @@ class ParseException {
   }
 }
 
-class TreeBuilder extends Tree {
-  constructor(root: Node) {
-    super(root);
+const tokens: [string, RegExp, boolean, number?][] = [
+  ['OPENP', /^\(/, false],
+  ['CLOSEP', /^\)/, false],
+  ['COLON', /^:/, false],
+  ['COMMA', /^,/, false],
+  ['SEMI', /^;/, false],
+  ['OPENA', /^\[&/, false],
+  ['CLOSEA', /^\]/, false],
+  ['OPENV', /^{/, false],
+  ['CLOSEV', /^}/, false],
+  ['EQ', /^=/, false],
+  ['HASH', /#/, false],
+  ['STRING', /^"(?:[^"]|"")+"/, true],
+  ['STRING', /^'(?:[^']|'')+'/, true],
+  ['STRING', /^[^,():;[\]#]+(?:\([^)]*\))?/, true, 0],
+  ['STRING', /^[^,[\]{}=]+/, true, 1],
+];
+
+export function readNewick(newick: string): Tree {
+  const tokenList = doLex(newick);
+  const rootNode = doParse(tokenList, newick);
+
+  const tree = new Tree(rootNode);
+  if (tree.root.branchLength === 0.0) {
+    tree.root.branchLength = undefined;
   }
+
+  return tree;
 }
 
-export class TreeFromNewick extends TreeBuilder {
-  static tokens: [string, RegExp, boolean, number?][] = [
-    ['OPENP', /^\(/, false],
-    ['CLOSEP', /^\)/, false],
-    ['COLON', /^:/, false],
-    ['COMMA', /^,/, false],
-    ['SEMI', /^;/, false],
-    ['OPENA', /^\[&/, false],
-    ['CLOSEA', /^\]/, false],
-    ['OPENV', /^{/, false],
-    ['CLOSEV', /^}/, false],
-    ['EQ', /^=/, false],
-    ['HASH', /#/, false],
-    ['STRING', /^"(?:[^"]|"")+"/, true],
-    ['STRING', /^'(?:[^']|'')+'/, true],
-    ['STRING', /^[^,():;[\]#]+(?:\([^)]*\))?/, true, 0],
-    ['STRING', /^[^,[\]{}=]+/, true, 1],
-  ];
+function doLex(newick: string): Token[] {
+  const tokenList: Token[] = [];
+  let idx = 0;
 
-  constructor(newick: string) {
-    const tokenList = TreeFromNewick.doLex(newick);
-    const rootNode = TreeFromNewick.doParse(tokenList, newick);
+  // Lexer has two modes: 0 (default) and 1 (attribute mode)
+  let lexMode = 0;
 
-    super(rootNode);
-
-    if (this.root.branchLength === 0.0) {
-      this.root.branchLength = undefined;
+  while (idx < newick.length) {
+    // Skip over whitespace:
+    const wsMatch = /^\s/.exec(newick.slice(idx));
+    if (wsMatch !== null && wsMatch.index === 0) {
+      idx += wsMatch[0].length;
+      continue;
     }
-  }
 
-  static doLex(newick: string): Token[] {
-    const tokenList: Token[] = [];
-    let idx = 0;
-
-    // Lexer has two modes: 0 (default) and 1 (attribute mode)
-    let lexMode = 0;
-
-    while (idx < newick.length) {
-      // Skip over whitespace:
-      const wsMatch = /^\s/.exec(newick.slice(idx));
-      if (wsMatch !== null && wsMatch.index === 0) {
-        idx += wsMatch[0].length;
+    let matchFound = false;
+    for (let k = 0; k < tokens.length; k++) {
+      // Skip lexer rules not applying to mode:
+      if (tokens[k].length > 3 && tokens[k][3] !== lexMode) {
         continue;
       }
 
-      let matchFound = false;
-      for (let k = 0; k < this.tokens.length; k++) {
-        // Skip lexer rules not applying to this mode:
-        if (this.tokens[k].length > 3 && this.tokens[k][3] !== lexMode) {
-          continue;
+      const match = tokens[k][1].exec(newick.slice(idx));
+      if (match !== null && match.index === 0) {
+        let value = match[0];
+
+        if (tokens[k][2]) {
+          if (tokens[k][0] === 'STRING') {
+            value = value.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+            value = value.replace("''", "'").replace('""', '"');
+          }
         }
 
-        const match = this.tokens[k][1].exec(newick.slice(idx));
-        if (match !== null && match.index === 0) {
-          let value = match[0];
+        tokenList.push([tokens[k][0], value, idx]);
 
-          if (this.tokens[k][2]) {
-            if (this.tokens[k][0] === 'STRING') {
-              value = value.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
-              value = value.replace("''", "'").replace('""', '"');
-            }
-          }
-
-          tokenList.push([this.tokens[k][0], value, idx]);
-
-          switch (this.tokens[k][0]) {
-            case 'OPENA':
-              lexMode = 1;
-              break;
-            case 'CLOSEA':
-              lexMode = 0;
-              break;
-            default:
-              break;
-          }
-
-          matchFound = true;
-          idx += match[0].length;
-          break;
+        switch (tokens[k][0]) {
+          case 'OPENA':
+            lexMode = 1;
+            break;
+          case 'CLOSEA':
+            lexMode = 0;
+            break;
+          default:
+            break;
         }
-      }
 
-      if (!matchFound) {
-        throw new ParseException(
-          `Error reading character ${newick[idx]} at position ${idx}`
-        );
+        matchFound = true;
+        idx += match[0].length;
+        break;
       }
     }
 
-    return tokenList;
-  }
-
-  static doParse(tokenList: Token[], newick: string): Node {
-    let thisNodeID = 0;
-
-    let idx = 0;
-    const treeRoot = ruleT();
-    return treeRoot;
-
-    function getContext(flank: number) {
-      const strIdx = tokenList[idx][2];
-      const startIdx = strIdx >= flank ? strIdx - flank : 0;
-      const stopIdx =
-        newick.length - strIdx >= flank ? strIdx + flank : newick.length;
-
-      return {
-        left: newick.slice(startIdx, strIdx),
-        at: newick[strIdx],
-        right: newick.slice(strIdx + 1, stopIdx),
-      };
-    }
-
-    function acceptToken(token: string, mandatory: boolean) {
-      if (idx < tokenList.length && tokenList[idx][0] === token) {
-        idx += 1;
-        return true;
-      } else {
-        if (mandatory)
-          if (idx < tokenList.length) {
-            throw new ParseException(
-              `Expected token <b>${token}</b> but found <b>${tokenList[idx][0]}</b> (${tokenList[idx][1]}) at string position <b>${tokenList[idx][2]}</b>.`,
-              getContext(15)
-            );
-          } else {
-            throw new ParseException(
-              'Newick string terminated early. Expected token ' + token + '.'
-            );
-          }
-        else return false;
-      }
-    }
-
-    function ruleT() {
-      const node = ruleN(undefined);
-
-      if (!acceptToken('SEMI', false) && acceptToken('COMMA', false))
-        throw new ParseException('Tree/network with multiple roots found.');
-
-      return node;
-    }
-
-    function ruleN(parent?: Node) {
-      const node = new Node(thisNodeID++);
-      if (parent !== undefined) parent.addChild(node);
-
-      ruleC(node);
-      ruleL(node);
-      ruleH(node);
-      ruleA(node);
-      ruleB(node);
-
-      return node;
-    }
-
-    function ruleC(node: Node) {
-      if (acceptToken('OPENP', false)) {
-        ruleN(node);
-        ruleM(node);
-        acceptToken('CLOSEP', true);
-      }
-    }
-
-    function ruleM(node: Node) {
-      if (acceptToken('COMMA', false)) {
-        ruleN(node);
-        ruleM(node);
-      }
-    }
-
-    function ruleL(node: Node) {
-      if (acceptToken('STRING', false)) {
-        node.label = tokenList[idx - 1][1];
-      }
-    }
-
-    function ruleH(node: Node) {
-      if (acceptToken('HASH', false)) {
-        acceptToken('STRING', true);
-        node.hybridID = Number(tokenList[idx - 1][1]);
-      }
-    }
-    function ruleA(node: Node) {
-      if (acceptToken('OPENA', false)) {
-        ruleD(node);
-        ruleE(node);
-        acceptToken('CLOSEA', true);
-      }
-    }
-    function isStringOrStringArrayOrNull(
-      value: RuleQResult
-    ): value is string | string[] {
-      return (
-        typeof value === 'string' ||
-        (Array.isArray(value) &&
-          value.every(item => typeof item === 'string')) ||
-        value == null
+    if (!matchFound) {
+      throw new ParseException(
+        `Error reading character ${newick[idx]} at position ${idx}`
       );
     }
-    function ruleD(node: Node) {
-      acceptToken('STRING', true);
-      const key = tokenList[idx - 1][1];
-      acceptToken('EQ', true);
-      const value = ruleQ();
-      if (isStringOrStringArrayOrNull(value)) {
-        node.annotation[key] = value;
-      }
-    }
+  }
 
-    type RuleQResult = string | RuleQResult[] | null;
+  return tokenList;
+}
 
-    function ruleQ(): RuleQResult {
-      let value;
-      if (acceptToken('STRING', false)) value = tokenList[idx - 1][1];
-      else if (acceptToken('OPENV', false)) {
-        value = [ruleQ()].concat(ruleW());
-        acceptToken('CLOSEV', true);
-      } else value = null;
+function doParse(tokenList: Token[], newick: string): Node {
+  let thisNodeID = 0;
 
-      return value;
-    }
+  let idx = 0;
+  const treeRoot = ruleT();
+  return treeRoot;
 
-    function ruleW(): RuleQResult {
-      if (acceptToken('COMMA', false)) {
-        return [ruleQ()].concat(ruleW());
-      } else return [];
-    }
+  function getContext(flank: number) {
+    const strIdx = tokenList[idx][2];
+    const startIdx = strIdx >= flank ? strIdx - flank : 0;
+    const stopIdx =
+      newick.length - strIdx >= flank ? strIdx + flank : newick.length;
 
-    function ruleE(node: Node) {
-      if (acceptToken('COMMA', false)) {
-        ruleD(node);
-        ruleE(node);
-      }
-    }
+    return {
+      left: newick.slice(startIdx, strIdx),
+      at: newick[strIdx],
+      right: newick.slice(strIdx + 1, stopIdx),
+    };
+  }
 
-    function ruleB(node: Node) {
-      if (acceptToken('COLON', false)) {
-        acceptToken('STRING', true);
-
-        const length = Number(tokenList[idx - 1][1]);
-        if (String(length) !== 'NaN') node.branchLength = length;
-        else
+  function acceptToken(token: string, mandatory: boolean) {
+    if (idx < tokenList.length && tokenList[idx][0] === token) {
+      idx += 1;
+      return true;
+    } else {
+      if (mandatory)
+        if (idx < tokenList.length) {
           throw new ParseException(
-            'Expected numerical branch length. Found ' +
-              tokenList[idx - 1][1] +
-              ' instead.'
+            `Expected token <b>${token}</b> but found <b>${tokenList[idx][0]}</b> (${tokenList[idx][1]}) at string position <b>${tokenList[idx][2]}</b>.`,
+            getContext(15)
           );
-
-        ruleR();
-
-        ruleA(node);
-      }
+        } else {
+          throw new ParseException(
+            'Newick string terminated early. Expected token ' + token + '.'
+          );
+        }
+      else return false;
     }
+  }
 
-    function ruleR() {
-      if (acceptToken('COLON', false)) {
-        acceptToken('STRING', false);
+  function ruleT() {
+    const node = ruleN(undefined);
 
-        ruleR();
-      }
+    if (!acceptToken('SEMI', false) && acceptToken('COMMA', false))
+      throw new ParseException('Tree/network with multiple roots found.');
+
+    return node;
+  }
+
+  function ruleN(parent?: Node) {
+    const node = new Node(thisNodeID++);
+    if (parent !== undefined) parent.addChild(node);
+
+    ruleC(node);
+    ruleL(node);
+    ruleH(node);
+    ruleA(node);
+    ruleB(node);
+
+    return node;
+  }
+
+  function ruleC(node: Node) {
+    if (acceptToken('OPENP', false)) {
+      ruleN(node);
+      ruleM(node);
+      acceptToken('CLOSEP', true);
+    }
+  }
+
+  function ruleM(node: Node) {
+    if (acceptToken('COMMA', false)) {
+      ruleN(node);
+      ruleM(node);
+    }
+  }
+
+  function ruleL(node: Node) {
+    if (acceptToken('STRING', false)) {
+      node.label = tokenList[idx - 1][1];
+    }
+  }
+
+  function ruleH(node: Node) {
+    if (acceptToken('HASH', false)) {
+      acceptToken('STRING', true);
+      node.hybridID = Number(tokenList[idx - 1][1]);
+    }
+  }
+  function ruleA(node: Node) {
+    if (acceptToken('OPENA', false)) {
+      ruleD(node);
+      ruleE(node);
+      acceptToken('CLOSEA', true);
+    }
+  }
+  function isStringOrStringArrayOrNull(
+    value: RuleQResult
+  ): value is string | string[] {
+    return (
+      typeof value === 'string' ||
+      (Array.isArray(value) && value.every(item => typeof item === 'string')) ||
+      value == null
+    );
+  }
+  function ruleD(node: Node) {
+    acceptToken('STRING', true);
+    const key = tokenList[idx - 1][1];
+    acceptToken('EQ', true);
+    const value = ruleQ();
+    if (isStringOrStringArrayOrNull(value)) {
+      node.annotation[key] = value;
+    }
+  }
+
+  type RuleQResult = string | RuleQResult[] | null;
+
+  function ruleQ(): RuleQResult {
+    let value;
+    if (acceptToken('STRING', false)) value = tokenList[idx - 1][1];
+    else if (acceptToken('OPENV', false)) {
+      value = [ruleQ()].concat(ruleW());
+      acceptToken('CLOSEV', true);
+    } else value = null;
+
+    return value;
+  }
+
+  function ruleW(): RuleQResult {
+    if (acceptToken('COMMA', false)) {
+      return [ruleQ()].concat(ruleW());
+    } else return [];
+  }
+
+  function ruleE(node: Node) {
+    if (acceptToken('COMMA', false)) {
+      ruleD(node);
+      ruleE(node);
+    }
+  }
+
+  function ruleB(node: Node) {
+    if (acceptToken('COLON', false)) {
+      acceptToken('STRING', true);
+
+      const length = Number(tokenList[idx - 1][1]);
+      if (String(length) !== 'NaN') node.branchLength = length;
+      else
+        throw new ParseException(
+          'Expected numerical branch length. Found ' +
+            tokenList[idx - 1][1] +
+            ' instead.'
+        );
+
+      ruleR();
+
+      ruleA(node);
+    }
+  }
+
+  function ruleR() {
+    if (acceptToken('COLON', false)) {
+      acceptToken('STRING', false);
+
+      ruleR();
     }
   }
 }
+
+//////////////// Old version below //////////////////
+
+// type Token = [string, string, number];
+
+// class ParseException {
+//   message: string;
+
+//   constructor(
+//     message: string,
+//     context?: { left: string; at: string; right: string }
+//   ) {
+//     this.message = message;
+
+//     if (context !== undefined) {
+//       this.message +=
+//         '<br><br>' +
+//         'Error context:<br> "... ' +
+//         context.left +
+//         "<span class='cursor'>" +
+//         context.at +
+//         '</span>' +
+//         context.right +
+//         ' ... "';
+//     }
+//   }
+// }
+
+// class TreeBuilder extends Tree {
+//   constructor(root: Node) {
+//     super(root);
+//   }
+// }
+
+// export class TreeFromNewick extends TreeBuilder {
+//   static tokens: [string, RegExp, boolean, number?][] = [
+//     ['OPENP', /^\(/, false],
+//     ['CLOSEP', /^\)/, false],
+//     ['COLON', /^:/, false],
+//     ['COMMA', /^,/, false],
+//     ['SEMI', /^;/, false],
+//     ['OPENA', /^\[&/, false],
+//     ['CLOSEA', /^\]/, false],
+//     ['OPENV', /^{/, false],
+//     ['CLOSEV', /^}/, false],
+//     ['EQ', /^=/, false],
+//     ['HASH', /#/, false],
+//     ['STRING', /^"(?:[^"]|"")+"/, true],
+//     ['STRING', /^'(?:[^']|'')+'/, true],
+//     ['STRING', /^[^,():;[\]#]+(?:\([^)]*\))?/, true, 0],
+//     ['STRING', /^[^,[\]{}=]+/, true, 1],
+//   ];
+
+//   constructor(newick: string) {
+//     const tokenList = TreeFromNewick.doLex(newick);
+//     const rootNode = TreeFromNewick.doParse(tokenList, newick);
+
+//     super(rootNode);
+
+//     if (this.root.branchLength === 0.0) {
+//       this.root.branchLength = undefined;
+//     }
+//   }
+
+//   static doLex(newick: string): Token[] {
+//     const tokenList: Token[] = [];
+//     let idx = 0;
+
+//     // Lexer has two modes: 0 (default) and 1 (attribute mode)
+//     let lexMode = 0;
+
+//     while (idx < newick.length) {
+//       // Skip over whitespace:
+//       const wsMatch = /^\s/.exec(newick.slice(idx));
+//       if (wsMatch !== null && wsMatch.index === 0) {
+//         idx += wsMatch[0].length;
+//         continue;
+//       }
+
+//       let matchFound = false;
+//       for (let k = 0; k < this.tokens.length; k++) {
+//         // Skip lexer rules not applying to this mode:
+//         if (this.tokens[k].length > 3 && this.tokens[k][3] !== lexMode) {
+//           continue;
+//         }
+
+//         const match = this.tokens[k][1].exec(newick.slice(idx));
+//         if (match !== null && match.index === 0) {
+//           let value = match[0];
+
+//           if (this.tokens[k][2]) {
+//             if (this.tokens[k][0] === 'STRING') {
+//               value = value.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+//               value = value.replace("''", "'").replace('""', '"');
+//             }
+//           }
+
+//           tokenList.push([this.tokens[k][0], value, idx]);
+
+//           switch (this.tokens[k][0]) {
+//             case 'OPENA':
+//               lexMode = 1;
+//               break;
+//             case 'CLOSEA':
+//               lexMode = 0;
+//               break;
+//             default:
+//               break;
+//           }
+
+//           matchFound = true;
+//           idx += match[0].length;
+//           break;
+//         }
+//       }
+
+//       if (!matchFound) {
+//         throw new ParseException(
+//           `Error reading character ${newick[idx]} at position ${idx}`
+//         );
+//       }
+//     }
+
+//     return tokenList;
+//   }
+
+//   static doParse(tokenList: Token[], newick: string): Node {
+//     let thisNodeID = 0;
+
+//     let idx = 0;
+//     const treeRoot = ruleT();
+//     return treeRoot;
+
+//     function getContext(flank: number) {
+//       const strIdx = tokenList[idx][2];
+//       const startIdx = strIdx >= flank ? strIdx - flank : 0;
+//       const stopIdx =
+//         newick.length - strIdx >= flank ? strIdx + flank : newick.length;
+
+//       return {
+//         left: newick.slice(startIdx, strIdx),
+//         at: newick[strIdx],
+//         right: newick.slice(strIdx + 1, stopIdx),
+//       };
+//     }
+
+//     function acceptToken(token: string, mandatory: boolean) {
+//       if (idx < tokenList.length && tokenList[idx][0] === token) {
+//         idx += 1;
+//         return true;
+//       } else {
+//         if (mandatory)
+//           if (idx < tokenList.length) {
+//             throw new ParseException(
+//               `Expected token <b>${token}</b> but found <b>${tokenList[idx][0]}</b> (${tokenList[idx][1]}) at string position <b>${tokenList[idx][2]}</b>.`,
+//               getContext(15)
+//             );
+//           } else {
+//             throw new ParseException(
+//               'Newick string terminated early. Expected token ' + token + '.'
+//             );
+//           }
+//         else return false;
+//       }
+//     }
+
+//     function ruleT() {
+//       const node = ruleN(undefined);
+
+//       if (!acceptToken('SEMI', false) && acceptToken('COMMA', false))
+//         throw new ParseException('Tree/network with multiple roots found.');
+
+//       return node;
+//     }
+
+//     function ruleN(parent?: Node) {
+//       const node = new Node(thisNodeID++);
+//       if (parent !== undefined) parent.addChild(node);
+
+//       ruleC(node);
+//       ruleL(node);
+//       ruleH(node);
+//       ruleA(node);
+//       ruleB(node);
+
+//       return node;
+//     }
+
+//     function ruleC(node: Node) {
+//       if (acceptToken('OPENP', false)) {
+//         ruleN(node);
+//         ruleM(node);
+//         acceptToken('CLOSEP', true);
+//       }
+//     }
+
+//     function ruleM(node: Node) {
+//       if (acceptToken('COMMA', false)) {
+//         ruleN(node);
+//         ruleM(node);
+//       }
+//     }
+
+//     function ruleL(node: Node) {
+//       if (acceptToken('STRING', false)) {
+//         node.label = tokenList[idx - 1][1];
+//       }
+//     }
+
+//     function ruleH(node: Node) {
+//       if (acceptToken('HASH', false)) {
+//         acceptToken('STRING', true);
+//         node.hybridID = Number(tokenList[idx - 1][1]);
+//       }
+//     }
+//     function ruleA(node: Node) {
+//       if (acceptToken('OPENA', false)) {
+//         ruleD(node);
+//         ruleE(node);
+//         acceptToken('CLOSEA', true);
+//       }
+//     }
+//     function isStringOrStringArrayOrNull(
+//       value: RuleQResult
+//     ): value is string | string[] {
+//       return (
+//         typeof value === 'string' ||
+//         (Array.isArray(value) &&
+//           value.every(item => typeof item === 'string')) ||
+//         value == null
+//       );
+//     }
+//     function ruleD(node: Node) {
+//       acceptToken('STRING', true);
+//       const key = tokenList[idx - 1][1];
+//       acceptToken('EQ', true);
+//       const value = ruleQ();
+//       if (isStringOrStringArrayOrNull(value)) {
+//         node.annotation[key] = value;
+//       }
+//     }
+
+//     type RuleQResult = string | RuleQResult[] | null;
+
+//     function ruleQ(): RuleQResult {
+//       let value;
+//       if (acceptToken('STRING', false)) value = tokenList[idx - 1][1];
+//       else if (acceptToken('OPENV', false)) {
+//         value = [ruleQ()].concat(ruleW());
+//         acceptToken('CLOSEV', true);
+//       } else value = null;
+
+//       return value;
+//     }
+
+//     function ruleW(): RuleQResult {
+//       if (acceptToken('COMMA', false)) {
+//         return [ruleQ()].concat(ruleW());
+//       } else return [];
+//     }
+
+//     function ruleE(node: Node) {
+//       if (acceptToken('COMMA', false)) {
+//         ruleD(node);
+//         ruleE(node);
+//       }
+//     }
+
+//     function ruleB(node: Node) {
+//       if (acceptToken('COLON', false)) {
+//         acceptToken('STRING', true);
+
+//         const length = Number(tokenList[idx - 1][1]);
+//         if (String(length) !== 'NaN') node.branchLength = length;
+//         else
+//           throw new ParseException(
+//             'Expected numerical branch length. Found ' +
+//               tokenList[idx - 1][1] +
+//               ' instead.'
+//           );
+
+//         ruleR();
+
+//         ruleA(node);
+//       }
+//     }
+
+//     function ruleR() {
+//       if (acceptToken('COLON', false)) {
+//         acceptToken('STRING', false);
+
+//         ruleR();
+//       }
+//     }
+//   }
+// }

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -172,80 +172,23 @@ export class Tree {
     return this.recombEdgeMap;
   }
 
-  // Sort nodes according to clade sizes.
-  sortNodes(decending: boolean): void {
-    if (this.root === undefined) return;
-
-    function sortNodesRecurse(node: Node): number {
-      let size = 1;
-      const childSizes: { [key: number]: number } = {};
-      for (let i = 0; i < node.children.length; i++) {
-        const thisChildSize: number = sortNodesRecurse(node.children[i]);
-        size += thisChildSize;
-        childSizes[node.children[i].id] = thisChildSize;
-      }
-
-      node.children.sort((a: Node, b: Node) => {
-        if (decending) return childSizes[b.id] - childSizes[a.id];
-        else return childSizes[a.id] - childSizes[b.id];
-      });
-
-      return size;
-    }
-
-    sortNodesRecurse(this.root);
-
-    // Clear out-of-date leaf list
-    this.leafList = undefined;
+  // return subtree of tree
+  getSubtree(node: Node): Tree {
+    return new Tree(node);
   }
 
-  // Shuffle nodes
-  shuffleNodes(): void {
-    if (this.root === undefined) return;
-
-    function shuffleArray(array: any[]): void {
-      for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
-      }
+  // get all tip names from tree or from node
+  getTipLabels(node?: Node): (string | undefined)[] {
+    let tips: (string | undefined)[];
+    if (node !== undefined) {
+      tips = this.getSubtree(node)
+        .getLeafList()
+        .map(e => e.id.toString());
+    } else {
+      tips = this.getLeafList().map(e => e.label);
     }
 
-    function shuffleNodesRecurse(node: Node): void {
-      for (let i = 0; i < node.children.length; i++)
-        shuffleNodesRecurse(node.children[i]);
-
-      shuffleArray(node.children);
-    }
-
-    shuffleNodesRecurse(this.root);
-  }
-  // Tree methods
-
-  // Collapse zero-length edges:
-  collapseZeroLengthEdges(): void {
-    this.root.applyPreOrder(function (node: Node) {
-      const childrenToConsider = node.children.slice();
-      while (childrenToConsider.length > 0) {
-        const child = childrenToConsider.pop();
-        if (child === undefined) continue;
-        if (child.height == node.height) {
-          node.removeChild(child);
-
-          // Does this do the right thing for polytomy dummy nodes?
-          node.annotation = child.annotation;
-          node.label = child.label;
-
-          for (let j = 0; j < child.children.length; j++) {
-            const grandChild = child.children[j];
-            node.addChild(grandChild);
-            childrenToConsider.push(grandChild);
-          }
-        }
-      }
-    });
-
-    // Invalidate cached leaf and node lists
-    this.clearCaches();
+    return tips;
   }
 
   // Sum of all defined branch lengths
@@ -404,6 +347,80 @@ export class Tree {
     }
   }
 
+  // // Collapse zero-length edges:
+  // collapseZeroLengthEdges(): void {
+  //   this.root.applyPreOrder(function (node: Node) {
+  //     const childrenToConsider = node.children.slice();
+  //     while (childrenToConsider.length > 0) {
+  //       const child = childrenToConsider.pop();
+  //       if (child === undefined) continue;
+  //       if (child.height == node.height) {
+  //         node.removeChild(child);
+
+  //         // Does this do the right thing for polytomy dummy nodes?
+  //         node.annotation = child.annotation;
+  //         node.label = child.label;
+
+  //         for (let j = 0; j < child.children.length; j++) {
+  //           const grandChild = child.children[j];
+  //           node.addChild(grandChild);
+  //           childrenToConsider.push(grandChild);
+  //         }
+  //       }
+  //     }
+  //   });
+
+  //   // Invalidate cached leaf and node lists
+  //   this.clearCaches();
+  // }
+
+  // // Sort nodes according to clade sizes.
+  // sortNodes(decending: boolean): void {
+  //   if (this.root === undefined) return;
+
+  //   function sortNodesRecurse(node: Node): number {
+  //     let size = 1;
+  //     const childSizes: { [key: number]: number } = {};
+  //     for (let i = 0; i < node.children.length; i++) {
+  //       const thisChildSize: number = sortNodesRecurse(node.children[i]);
+  //       size += thisChildSize;
+  //       childSizes[node.children[i].id] = thisChildSize;
+  //     }
+
+  //     node.children.sort((a: Node, b: Node) => {
+  //       if (decending) return childSizes[b.id] - childSizes[a.id];
+  //       else return childSizes[a.id] - childSizes[b.id];
+  //     });
+
+  //     return size;
+  //   }
+
+  //   sortNodesRecurse(this.root);
+
+  //   // Clear out-of-date leaf list
+  //   this.leafList = undefined;
+  // }
+
+  // // Shuffle nodes
+  // shuffleNodes(): void {
+  //   if (this.root === undefined) return;
+
+  //   function shuffleArray(array: any[]): void {
+  //     for (let i = array.length - 1; i > 0; i--) {
+  //       const j = Math.floor(Math.random() * (i + 1));
+  //       [array[i], array[j]] = [array[j], array[i]];
+  //     }
+  //   }
+
+  //   function shuffleNodesRecurse(node: Node): void {
+  //     for (let i = 0; i < node.children.length; i++)
+  //       shuffleNodesRecurse(node.children[i]);
+
+  //     shuffleArray(node.children);
+  //   }
+
+  //   shuffleNodesRecurse(this.root);
+  // }
   // isRecombSrcNode(node: Node): boolean {
   //   if (node.hybridID !== undefined)
   //     return (

--- a/src/Write.ts
+++ b/src/Write.ts
@@ -1,85 +1,64 @@
 import { Node } from './Node';
 import { Tree } from './Tree';
 
-interface PhylogenyWriter {
-  (tree: Tree): string;
+export function writeNewick(tree: Tree): string {
+  let newickStr = '';
+
+  if (tree.root !== undefined)
+    newickStr += newickRecurse(tree.root, false) + ';';
+
+  return newickStr;
 }
 
-interface Write {
-  newick: PhylogenyWriter;
-  nexus: PhylogenyWriter;
-  //   phyloXML: PhylogenyWriter;
-  //   neXML: PhylogenyWriter;
+export function writeNexus(tree: Tree): string {
+  let nexusStr = '#NEXUS\n\nbegin trees;\n';
+
+  if (tree.root !== undefined)
+    nexusStr +=
+      `\ttree tree_1 = [&R] ${newickRecurse(tree.root, true)};` + '\n';
+
+  nexusStr += 'end;';
+
+  return nexusStr;
 }
 
-export const Write: Write = (function () {
-  //const phyloXMLNS = 'http://www.phyloxml.org';
-  //const neXMLNS = 'http://www.nexml.org/2009';
-  //const xsiNS = 'http://www.w3.org/2001/XMLSchema-instance';
-
-  function newickRecurse(node: Node, annotate: boolean): string {
-    let res = '';
-    if (!node.isLeaf()) {
-      res += '(';
-      for (let i = 0; i < node.children.length; i++) {
-        if (i > 0) res += ',';
-        res += newickRecurse(node.children[i], annotate);
-      }
-      res += ')';
+function newickRecurse(node: Node, annotate: boolean): string {
+  let res = '';
+  if (!node.isLeaf()) {
+    res += '(';
+    for (let i = 0; i < node.children.length; i++) {
+      if (i > 0) res += ',';
+      res += newickRecurse(node.children[i], annotate);
     }
+    res += ')';
+  }
 
-    if (node.label !== undefined) res += `"${node.label}"`;
+  if (node.label !== undefined) res += `"${node.label}"`;
 
-    if (node.hybridID !== undefined) res += `#${node.hybridID}`;
+  if (node.hybridID !== undefined) res += `#${node.hybridID}`;
 
-    if (annotate) {
-      const keys = Object.keys(node.annotation);
-      if (keys.length > 0) {
-        res += '[&';
-        for (let idx = 0; idx < keys.length; idx++) {
-          const key = keys[idx];
+  if (annotate) {
+    const keys = Object.keys(node.annotation);
+    if (keys.length > 0) {
+      res += '[&';
+      for (let idx = 0; idx < keys.length; idx++) {
+        const key = keys[idx];
 
-          if (idx > 0) res += ',';
-          res += `"${key}"=`;
-          const value = node.annotation[key];
-          if (Array.isArray(value)) {
-            res += `{${String(value.join(','))}}`; // Convert the array to a comma-separated string
-          } else {
-            res += `"${String(value)}"`; // Explicitly convert the value to a string
-          }
+        if (idx > 0) res += ',';
+        res += `"${key}"=`;
+        const value = node.annotation[key];
+        if (Array.isArray(value)) {
+          res += `{${String(value.join(','))}}`; // Convert the array to a comma-separated string
+        } else {
+          res += `"${String(value)}"`; // Explicitly convert the value to a string
         }
-        res += ']';
       }
+      res += ']';
     }
-
-    if (node.branchLength !== undefined) res += `:${node.branchLength}`;
-    else res += ':0.0';
-
-    return res;
   }
 
-  function newickWriter(tree: Tree): string {
-    let newickStr = '';
+  if (node.branchLength !== undefined) res += `:${node.branchLength}`;
+  else res += ':0.0';
 
-    if (tree.root !== undefined)
-      newickStr += newickRecurse(tree.root, false) + ';';
-
-    return newickStr;
-  }
-
-  function nexusWriter(tree: Tree): string {
-    let nexusStr = '#NEXUS\n\nbegin trees;\n';
-
-    if (tree.root !== undefined)
-      nexusStr +=
-        `\ttree tree_1 = [&R] ${newickRecurse(tree.root, true)};` + '\n';
-
-    nexusStr += 'end;';
-
-    return nexusStr;
-  }
-  return {
-    newick: newickWriter,
-    nexus: nexusWriter,
-  };
-})();
+  return res;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Node } from './Node';
 export { Tree } from './Tree';
-export { Write } from './Write';
-export { TreeFromNewick } from './Reader';
+export { writeNewick, writeNexus } from './Write';
+export { readNewick } from './Reader';

--- a/test/Reader.spec.ts
+++ b/test/Reader.spec.ts
@@ -1,10 +1,11 @@
-import { TreeFromNewick, Write } from '../src';
+import { writeNewick } from '../src/Write';
+import { readNewick } from '../src/Reader';
 
 describe('TreeFromNewick', () => {
   test('init', () => {
     const inNewick = '("A":1,("B":1,"C":1):1):0.0;';
-    const tree = new TreeFromNewick(inNewick);
-    const outNewick = Write.newick(tree); 
+    const tree = readNewick(inNewick);
+    const outNewick = writeNewick(tree); 
     expect(outNewick).toBe(inNewick);
   });
 });

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -1,7 +1,7 @@
 // phyloWriter.test.ts
 import { Node } from '../src/Node';
 import { Tree } from '../src/Tree';
-import { Write } from '../src/Write';
+import { writeNewick, writeNexus } from '../src/Write';
 
 describe('PhyloWriter', () => {
   const rootNode = new Node(0);
@@ -25,12 +25,12 @@ describe('PhyloWriter', () => {
   const tree = new Tree(rootNode);
 
   test('newickWriter', () => {
-    const newick = Write.newick(tree);
+    const newick = writeNewick(tree);
     expect(newick).toBe('("A":1,("B":1,"C":1):1):0.0;');
   });
 
   test('nexusWriter', () => {
-    const nexus = Write.nexus(tree);
+    const nexus = writeNexus(tree);
     expect(nexus).toBe(
       '#NEXUS\n\nbegin trees;\n\ttree tree_1 = [&R] ("A":1,("B":1,"C":1):1):0.0;\nend;'
     );


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Changes:
1) Reading and writing trees are now functions: `writeNewick(), writeNexus(), readNewick()`
2) Added tree methods to get a subtree of a node: `tree.getSubtree(Node)`
3) Added method to get the tips descending from a node/ all tips if node omitted: `tree.getTipLabels(Node)`

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
