### PR TITLE
fix: write functions include bool for annotation

### DIFF
--- a/docs/examples/annotations.md
+++ b/docs/examples/annotations.md
@@ -21,7 +21,7 @@ Altered annotations are then writtedn back to newick or nexus.
             }
         }
 
-        console.log(writeNewick)
+        console.log(writeNewick(tree, true))
         // (("A"[&"Type"="Red"]:0.0,"B"[&"Type"="Red"]:0.0):0.0,"C"[&"Type"="Yellow"]:0.0):0.0;
         // Note types changed ^
 ```

--- a/docs/examples/test/examples.spec.ts
+++ b/docs/examples/test/examples.spec.ts
@@ -113,7 +113,7 @@ describe('Examples', () => {
                 }
             }
         }
-        expect(writeNewick(tree)).not.toEqual(newick)
+        expect(writeNewick(tree, true)).not.toEqual(newick)
 
     })
 
@@ -131,7 +131,8 @@ describe('Examples', () => {
             }
         }
         
-        expect(writeNewick(tree)).not.toEqual(newick)
+        expect(writeNewick(tree, true)).not.toEqual(newick)
         
     })
+
 })

--- a/docs/examples/writer.md
+++ b/docs/examples/writer.md
@@ -15,7 +15,7 @@ import { writeNewick, writeNexus } from '../src/Write';
 The `writeNewick` function has the following signature:
 
 ```javascript
-writeNewick(tree: Tree): string
+writeNewick(tree: Tree, annotate: boolean = false): string
 ```
 
 **Parameters**
@@ -29,7 +29,7 @@ writeNewick(tree: Tree): string
 The `writeNexus` function has the following signature:
 
 ```javascript
-writeNexus(tree: Tree): string
+writeNexus(tree: Tree, annotate: boolean = true): string
 ```
 
 **Parameters**

--- a/src/Write.ts
+++ b/src/Write.ts
@@ -1,23 +1,30 @@
 import { Node } from './Node';
 import { Tree } from './Tree';
 
-/** Writes tree in .newick format. Undefined branch lengths set to 0. */
-export function writeNewick(tree: Tree): string {
+/** 
+ * Writes tree in .newick format. Undefined branch lengths set to 0.
+ * @param {tree} tree The tree to write
+ * @param {boolean} annotate Boolean to include annotations. Default is false.
+ */
+export function writeNewick(tree: Tree, annotate: boolean = false): string {
   let newickStr = '';
 
   if (tree.root !== undefined)
-    newickStr += newickRecurse(tree.root, true) + ';';
+    newickStr += newickRecurse(tree.root, annotate) + ';';
 
   return newickStr;
 }
 
-/** Writes tree in .nexus format. Undefined branch lengths set to 0. */
-export function writeNexus(tree: Tree): string {
+/** Writes tree in .nexus format. Undefined branch lengths set to 0.
+ * @param {tree} tree The tree to write
+ * @param {boolean} annotate Boolean to include annotations. Default is true.
+ */
+export function writeNexus(tree: Tree, annotate: boolean = true): string {
   let nexusStr = '#NEXUS\n\nbegin trees;\n';
 
   if (tree.root !== undefined)
     nexusStr +=
-      `\ttree tree_1 = [&R] ${newickRecurse(tree.root, true)};` + '\n';
+      `\ttree tree_1 = [&R] ${newickRecurse(tree.root, annotate)};` + '\n';
 
   nexusStr += 'end;';
 


### PR DESCRIPTION

### Description of change

dded boolean parameter `annotate` to `writeNexus()` and `writeNewick()` for whether to include annotations when writing tree. Docs updated accordingly.
