### PR TITLE
fix: add internal to external BL ratio example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can install PhyloJS using npm:
 npm install phylojs
 ```
 
-Please refer to the [Documentation](#) for more API documentation and examples of use for phylojs.
+Please refer to the [Documentation](clockor2.github.io/phylojs/) for more API documentation and examples of use for phylojs.
 
 ## IcyTree
 

--- a/docs/examples/ieRatio.md
+++ b/docs/examples/ieRatio.md
@@ -1,0 +1,40 @@
+Here, we demonstrate how we can caluclate a tree summary statistic at each internal node of a tree. We calculate the internal to external branch length ratio for the subtree descending from each internal node and add it as an annotation to each node. We define a function to calculate the internal to external branch length ratio `getBranchLengthRatio()` as well as demonstrate use of the `.isLeaf()` and `.applyPreOrder()` methods on the `Node` class.
+
+The internal to external branch length ratio is defined as the ratio of the sum of internal branch lenghts to the sum of external branch lengths (leading to tips). It is a commonly used statistic that describes how 'tippy' or 'stemmy' trees appear.
+
+
+```typescript
+// Internal to external branch length ratio
+    function getBranchLengthRatio(tree: Tree): number {
+
+      let sumInternal: number = 0.0;
+      let sumExternal: number = 0.0;
+
+      for (let i=0; i<tree.nodeList.length; i++) {
+        if(tree.nodeList[i].branchLength !== undefined){
+          if (tree.nodeList[i].isLeaf()) {
+            sumExternal += tree.nodeList[i].branchLength
+          } else {
+            sumInternal += tree.nodeList[i].branchLength
+          }
+        }
+      }
+      return sumInternal / sumExternal;
+    }
+
+    let nwk = `((a:2,b:2):1,(c:1,d:1):4);`
+    let tree = readNewick(nwk)
+
+    // IE ratio for subtrees descending from each node, except tips
+    tree.root.applyPreOrder((node: Node) => {
+      if(!node.isLeaf()) {
+        let ieRatio = getBranchLengthRatio(tree.getSubtree(node))
+        node.annotation = {ieRatio: ieRatio.toFixed(2)}
+      }
+    });
+
+    // Expect annotations in newick with `true` flag
+    console.log(writeNewick(tree, true))
+    // Returns:
+    // (("a":2,"b":2)[&"ieRatio"="0.25"]:1,("c":1,"d":1)[&"ieRatio"="2.00"]:4)["ieRatio"="0.83"]:0.0;
+```

--- a/docs/examples/test/examples.spec.ts
+++ b/docs/examples/test/examples.spec.ts
@@ -2,8 +2,7 @@
 //////// Testing examples for documentation /////////
 /////////////////////////////////////////////////////
 
-import { readNewick, readTreesFromPhyloXML } from '@phylojs';
-import { writeNewick } from '@phylojs';
+import { readNewick, readTreesFromPhyloXML, writeNewick, Tree } from '@phylojs';
 
 describe('Examples', () => {
   test('RTTR', () => {
@@ -192,4 +191,64 @@ describe('Examples', () => {
 
     expect(inNewick).not.toEqual(outNewick)
   })
+
+  test('getBranchLengthRatio()', () => {
+    function getBranchLengthRatio(tree: Tree): number {
+
+      let sumInternal: number = 0.0;
+      let sumExternal: number = 0.0;
+
+      for (let i=0; i<tree.nodeList.length; i++) {
+        if(tree.nodeList[i].branchLength !== undefined){
+          if (tree.nodeList[i].isLeaf()) {
+            sumExternal += tree.nodeList[i].branchLength
+          } else {
+            sumInternal += tree.nodeList[i].branchLength
+          }
+        }
+      }
+      return sumInternal / sumExternal;
+    }
+
+    let nwk = `((a:2,b:2):1,(c:2,d:2):1);`
+    let tree = readNewick(nwk)
+
+    expect(getBranchLengthRatio(tree)).toEqual(0.25)
+  })
+
+  test('IE BL ratio statistic', () => {
+    // Internal to external branch length ratio
+    function getBranchLengthRatio(tree: Tree): number {
+
+      let sumInternal: number = 0.0;
+      let sumExternal: number = 0.0;
+
+      for (let i=0; i<tree.nodeList.length; i++) {
+        if(tree.nodeList[i].branchLength !== undefined){
+          if (tree.nodeList[i].isLeaf()) {
+            sumExternal += tree.nodeList[i].branchLength
+          } else {
+            sumInternal += tree.nodeList[i].branchLength
+          }
+        }
+      }
+      return sumInternal / sumExternal;
+    }
+
+    let nwk = `((a:2,b:2):1,(c:1,d:1):4);`
+    let tree = readNewick(nwk)
+
+    // IE ratio for subtrees descending from each node, except tips
+    tree.root.applyPreOrder((node: Node) => {
+      if(!node.isLeaf()) {
+        let ieRatio = getBranchLengthRatio(tree.getSubtree(node))
+        node.annotation = {ieRatio: ieRatio.toFixed(2)}
+      }
+    });
+
+    // Expect annotations in newick with `true` flag
+    console.log(writeNewick(tree, true))
+    expect(writeNewick(tree, true)).not.toBe(nwk)
+  })
+
 });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,5 +60,6 @@ nav:
     - Working with annotations: examples/annotations.md
     - Working with arrays of trees: examples/treeArray.md
     - Writing trees: examples/writer.md
+    - Summary statistics: examples/ieRatio.md
   - API: 'typedoc'
   - Cite: cite.md


### PR DESCRIPTION
Added example for calculating internal to external branch length ratio for the subtree descending from each node in a tree. Also demonstrates adding these as annotations. 