### PR TITLE
fix: getters for node and leaf lists

### DIFF
--- a/docs/examples/reroot.md
+++ b/docs/examples/reroot.md
@@ -2,15 +2,15 @@
 
 In this example we will reroot at each node of a dummy tree and check that the tree length (the sum of all branch lengths) is identical each time.
 
-This example demonstrates use of the `.reroot`, `.getNodeList()`, and `.getTotalBranchLength()` methods.
+This example demonstrates use of the `.reroot`, `.nodeList()`, and `.getTotalBranchLength()` methods.
 
-Node that `.getNodeList()` returns an array of nodes (`Node[]`), the first of which is always the root. `.reroot()` throws an error if you try to reroot at the root, which is why we start out loop from the 1st rather than 0th node below.
+Node that `.nodeList()` returns an array of nodes (`Node[]`), the first of which is always the root. `.reroot()` throws an error if you try to reroot at the root, which is why we start out loop from the 1st rather than 0th node below.
 
 ```typescript
         let newick = '(("D_2000":1.0,"E_2003":1.2):3.0,("C_2005":2.5,("A_2010":1.8,"B_2011":1.07):1.0):1.2):4.0;'
         let tree = readNewick(newick)
 
-        let nodes = tree.getNodeList()
+        let nodes = tree.nodeList()
         
         let length: number[] = []
         // Note i starts at 1 as 0th node is the root

--- a/docs/examples/reroot.md
+++ b/docs/examples/reroot.md
@@ -2,15 +2,15 @@
 
 In this example we will reroot at each node of a dummy tree and check that the tree length (the sum of all branch lengths) is identical each time.
 
-This example demonstrates use of the `.reroot`, `.nodeList()`, and `.getTotalBranchLength()` methods.
+This example demonstrates use of the `.reroot`, `.nodeList`, and `.getTotalBranchLength()` methods.
 
-Node that `.nodeList()` returns an array of nodes (`Node[]`), the first of which is always the root. `.reroot()` throws an error if you try to reroot at the root, which is why we start out loop from the 1st rather than 0th node below.
+Node that `.nodeList` returns an array of nodes (`Node[]`), the first of which is always the root. `.reroot()` throws an error if you try to reroot at the root, which is why we start out loop from the 1st rather than 0th node below.
 
 ```typescript
         let newick = '(("D_2000":1.0,"E_2003":1.2):3.0,("C_2005":2.5,("A_2010":1.8,"B_2011":1.07):1.0):1.2):4.0;'
         let tree = readNewick(newick)
 
-        let nodes = tree.nodeList()
+        let nodes = tree.nodeList
         
         let length: number[] = []
         // Note i starts at 1 as 0th node is the root

--- a/docs/examples/test/examples.spec.ts
+++ b/docs/examples/test/examples.spec.ts
@@ -247,7 +247,6 @@ describe('Examples', () => {
     });
 
     // Expect annotations in newick with `true` flag
-    console.log(writeNewick(tree, true))
     expect(writeNewick(tree, true)).not.toBe(nwk)
   })
 

--- a/docs/examples/test/examples.spec.ts
+++ b/docs/examples/test/examples.spec.ts
@@ -84,7 +84,7 @@ describe('Examples', () => {
       '(("D_2000":1.0,"E_2003":1.2):3.0,("C_2005":2.5,("A_2010":1.8,"B_2011":1.07):1.0):1.2):4.0;';
     const tree = readNewick(newick);
 
-    const nodes = tree.getNodeList();
+    const nodes = tree.nodeList();
     const length: number[] = [];
 
     // We will reroot at each node and check that the length is the same

--- a/docs/examples/test/examples.spec.ts
+++ b/docs/examples/test/examples.spec.ts
@@ -84,7 +84,7 @@ describe('Examples', () => {
       '(("D_2000":1.0,"E_2003":1.2):3.0,("C_2005":2.5,("A_2010":1.8,"B_2011":1.07):1.0):1.2):4.0;';
     const tree = readNewick(newick);
 
-    const nodes = tree.nodeList();
+    const nodes = tree.nodeList;
     const length: number[] = [];
 
     // We will reroot at each node and check that the length is the same

--- a/docs/examples/tree.md
+++ b/docs/examples/tree.md
@@ -35,9 +35,9 @@ Here are the key methods for the Tree class:
 
 - `getTipLabels()`: Returns an array of labels of all leaf nodes in the tree.
 
-- `getNodeList()`: Returns an array of all nodes in the tree.
+- `nodeList()`: Returns an array of all nodes in the tree.
 
-- `getLeafList()`: Returns an array of all leaf nodes in the tree.
+- `leafList()`: Returns an array of all leaf nodes in the tree.
 
 ## Function usage
 
@@ -48,7 +48,7 @@ const rootNode = new Node(0);
 const tree = new Tree(rootNode);
 
 // Access nodes
-const nodes = tree.getNodeList();
+const nodes = tree.nodeList();
 
 // Reroot the tree at the second node
 tree.reroot(nodes[1]);

--- a/docs/examples/tree.md
+++ b/docs/examples/tree.md
@@ -48,7 +48,7 @@ const rootNode = new Node(0);
 const tree = new Tree(rootNode);
 
 // Access nodes
-const nodes = tree.nodeList();
+const nodes = tree.nodeList;
 
 // Reroot the tree at the second node
 tree.reroot(nodes[1]);

--- a/docs/examples/visualise.html
+++ b/docs/examples/visualise.html
@@ -19,7 +19,7 @@
     <script>
         let newick = `(Bovine:0.69395,(Gibbon:0.36079,(Orangutan:0.33636,(Gorilla:0.17147,(Chimp:1.19268,Human:0.11927):0.08386):0.06124):0.15057):0.54939,Mouse:1.21460);`
         let tree = phylojs.readNewick(newick)
-        let nNodes = tree.nodeList().length
+        let nNodes = tree.nodeList.length
 
         // Initial rendering
         const treeVis = new phylocanvas.PhylocanvasGL(
@@ -35,7 +35,7 @@
         function onClick() {
 
             let i = Math.floor(nNodes * Math.random() + 1) // Returns an integer from 1,...,nNodes
-            let node = tree.nodeList()[i]
+            let node = tree.nodeList[i]
 
             tree.reroot(node)
 

--- a/docs/examples/visualise.html
+++ b/docs/examples/visualise.html
@@ -19,7 +19,7 @@
     <script>
         let newick = `(Bovine:0.69395,(Gibbon:0.36079,(Orangutan:0.33636,(Gorilla:0.17147,(Chimp:1.19268,Human:0.11927):0.08386):0.06124):0.15057):0.54939,Mouse:1.21460);`
         let tree = phylojs.readNewick(newick)
-        let nNodes = tree.getNodeList().length
+        let nNodes = tree.nodeList().length
 
         // Initial rendering
         const treeVis = new phylocanvas.PhylocanvasGL(
@@ -35,7 +35,7 @@
         function onClick() {
 
             let i = Math.floor(nNodes * Math.random() + 1) // Returns an integer from 1,...,nNodes
-            let node = tree.getNodeList()[i]
+            let node = tree.nodeList()[i]
 
             tree.reroot(node)
 

--- a/docs/examples/visualise.md
+++ b/docs/examples/visualise.md
@@ -71,7 +71,7 @@ Finally, we can add the phylojs code to parse and reroot the tree as well as the
     <script>
         let newick = `(Bovine:0.69395,(Gibbon:0.36079,(Orangutan:0.33636,(Gorilla:0.17147,(Chimp:1.19268,Human:0.11927):0.08386):0.06124):0.15057):0.54939,Mouse:1.21460);`
         let tree = phylojs.readNewick(newick)
-        let nNodes = tree.getNodeList().length
+        let nNodes = tree.nodeList().length
 
         // Initial rendering
         const treeVis = new phylocanvas.PhylocanvasGL(
@@ -87,7 +87,7 @@ Finally, we can add the phylojs code to parse and reroot the tree as well as the
         function onClick() {
 
             let i = Math.floor(nNodes * Math.random() + 1) // Returns an integer from 1,...,nNodes
-            let node = tree.getNodeList()[i]
+            let node = tree.nodeList()[i]
 
             tree.reroot(node)
 

--- a/docs/examples/visualise.md
+++ b/docs/examples/visualise.md
@@ -71,7 +71,7 @@ Finally, we can add the phylojs code to parse and reroot the tree as well as the
     <script>
         let newick = `(Bovine:0.69395,(Gibbon:0.36079,(Orangutan:0.33636,(Gorilla:0.17147,(Chimp:1.19268,Human:0.11927):0.08386):0.06124):0.15057):0.54939,Mouse:1.21460);`
         let tree = phylojs.readNewick(newick)
-        let nNodes = tree.nodeList().length
+        let nNodes = tree.nodeList.length
 
         // Initial rendering
         const treeVis = new phylocanvas.PhylocanvasGL(
@@ -87,7 +87,7 @@ Finally, we can add the phylojs code to parse and reroot the tree as well as the
         function onClick() {
 
             let i = Math.floor(nNodes * Math.random() + 1) // Returns an integer from 1,...,nNodes
-            let node = tree.nodeList()[i]
+            let node = tree.nodeList[i]
 
             tree.reroot(node)
 

--- a/js/Tree.js
+++ b/js/Tree.js
@@ -9,8 +9,8 @@ function Tree(root) {
 // Tree methods
 
 // Compute node ages
-Tree.prototype.computeNodeAges = function() {
-    var heights = this.root.applyPreOrder(function(node) {
+Tree.prototype.computeNodeAges = function () {
+    var heights = this.root.applyPreOrder(function (node) {
         if (node.parent === undefined)
             node.height = 0.0;
         else {
@@ -25,21 +25,21 @@ Tree.prototype.computeNodeAges = function() {
     });
     var youngestHeight = Math.min.apply(null, heights);
 
-    this.isTimeTree = !Number.isNaN(youngestHeight) && (heights.length>1 || this.root.branchLength !== undefined);
+    this.isTimeTree = !Number.isNaN(youngestHeight) && (heights.length > 1 || this.root.branchLength !== undefined);
 
-    for (var i=0; i<this.getNodeList().length; i++)
-        this.getNodeList()[i].height -= youngestHeight;
+    for (var i = 0; i < this.nodeList().length; i++)
+        this.nodeList()[i].height -= youngestHeight;
 };
 
 // Assign new node IDs (use with care!)
-Tree.prototype.reassignNodeIDs = function() {
+Tree.prototype.reassignNodeIDs = function () {
     var nodeID = 0;
-    for (var i=0; i<this.getNodeList().length; i++)
-        this.getNodeList()[i].id = nodeID++;
+    for (var i = 0; i < this.nodeList().length; i++)
+        this.nodeList()[i].id = nodeID++;
 };
 
 // Clear various node caches:
-Tree.prototype.clearCaches = function() {
+Tree.prototype.clearCaches = function () {
     this.nodeList = undefined;
     this.nodeIDMap = undefined;
     this.leafList = undefined;
@@ -48,9 +48,9 @@ Tree.prototype.clearCaches = function() {
 
 // Retrieve list of nodes in tree.
 // (Should maybe use accessor function for this.)
-Tree.prototype.getNodeList = function() {
+Tree.prototype.getNodeList = function () {
     if (this.nodeList === undefined && this.root !== undefined) {
-        this.nodeList = this.root.applyPreOrder(function(node) {
+        this.nodeList = this.root.applyPreOrder(function (node) {
             return node;
         });
     }
@@ -59,11 +59,11 @@ Tree.prototype.getNodeList = function() {
 };
 
 // Obtain node having given string representation:
-Tree.prototype.getNode = function(nodeID) {
+Tree.prototype.getNode = function (nodeID) {
     if (this.nodeIDMap === undefined && this.root !== undefined) {
         this.nodeIDMap = {};
-        for (var i=0; i<this.getNodeList().length; i++) {
-            var node = this.getNodeList()[i];
+        for (var i = 0; i < this.nodeList().length; i++) {
+            var node = this.nodeList()[i];
             this.nodeIDMap[node] = node;
         }
     }
@@ -72,9 +72,9 @@ Tree.prototype.getNode = function(nodeID) {
 };
 
 // Retrieve list of leaves in tree, in correct order.
-Tree.prototype.getLeafList = function() {
+Tree.prototype.getLeafList = function () {
     if (this.leafList === undefined && this.root !== undefined) {
-        this.leafList = this.root.applyPreOrder(function(node) {
+        this.leafList = this.root.applyPreOrder(function (node) {
             if (node.isLeaf())
                 return node;
             else
@@ -86,13 +86,13 @@ Tree.prototype.getLeafList = function() {
 };
 
 // Retrieve map from recomb edge IDs to src/dest node pairs
-Tree.prototype.getRecombEdgeMap = function() {
+Tree.prototype.getRecombEdgeMap = function () {
     if (this.recombEdgeMap === undefined) {
 
         var node, i;
         var hybridNodeList;
         if (this.root !== undefined) {
-            hybridNodeList = this.root.applyPreOrder(function(node) {
+            hybridNodeList = this.root.applyPreOrder(function (node) {
                 if (node.isHybrid())
                     return node;
                 else
@@ -104,7 +104,7 @@ Tree.prototype.getRecombEdgeMap = function() {
 
         var srcHybridIDMap = {};
         var destHybridIDMap = {};
-        for (i=0; i<hybridNodeList.length; i++) {
+        for (i = 0; i < hybridNodeList.length; i++) {
             node = hybridNodeList[i];
             if (node.isLeaf()) {
                 if (node.hybridID in destHybridIDMap)
@@ -136,37 +136,37 @@ Tree.prototype.getRecombEdgeMap = function() {
     return this.recombEdgeMap;
 };
 
-Tree.prototype.isRecombSrcNode = function(node) {
+Tree.prototype.isRecombSrcNode = function (node) {
     return node.isHybrid() && this.getRecombEdgeMap()[node.hybridID][0] == node;
 };
 
-Tree.prototype.isRecombDestNode = function(node) {
+Tree.prototype.isRecombDestNode = function (node) {
     return node.isHybrid() && this.getRecombEdgeMap()[node.hybridID][0] != node;
 };
 
-Tree.prototype.isNetwork = function() {
+Tree.prototype.isNetwork = function () {
     return Object.keys(this.getRecombEdgeMap()).length > 0;
 };
 
 // Sort nodes according to clade sizes.
-Tree.prototype.sortNodes = function(decending) {
+Tree.prototype.sortNodes = function (decending) {
     if (this.root === undefined)
         return;
 
     function sortNodesRecurse(node) {
         var size = 1;
         var childSizes = {};
-        for (var i=0; i<node.children.length; i++) {
+        for (var i = 0; i < node.children.length; i++) {
             var thisChildSize = sortNodesRecurse(node.children[i]);
             size += thisChildSize;
             childSizes[node.children[i]] = thisChildSize;
         }
 
-        node.children.sort(function(a,b) {
+        node.children.sort(function (a, b) {
             if (decending)
-                return childSizes[b]-childSizes[a];
+                return childSizes[b] - childSizes[a];
             else
-                return childSizes[a]-childSizes[b];
+                return childSizes[a] - childSizes[b];
         });
 
         return size;
@@ -179,7 +179,7 @@ Tree.prototype.sortNodes = function(decending) {
 };
 
 // Shuffle nodes
-Tree.prototype.shuffleNodes = function() {
+Tree.prototype.shuffleNodes = function () {
     if (this.root === undefined)
         return;
 
@@ -191,7 +191,7 @@ Tree.prototype.shuffleNodes = function() {
     }
 
     function shuffleNodesRecurse(node) {
-        for (let i=0; i<node.children.length; i++)
+        for (let i = 0; i < node.children.length; i++)
             shuffleNodesRecurse(node.children[i]);
 
         shuffleArray(node.children);
@@ -201,20 +201,20 @@ Tree.prototype.shuffleNodes = function() {
 }
 
 // Minimize distance between hybrid pairs
-Tree.prototype.minimizeHybridSeparation = function() {
+Tree.prototype.minimizeHybridSeparation = function () {
 
     var recombEdgeMap = this.getRecombEdgeMap();
 
     for (var recombID in recombEdgeMap) {
         var srcNode = recombEdgeMap[recombID][0];
 
-        for (var i=1; i<recombEdgeMap[recombID].length; i++) {
+        for (var i = 1; i < recombEdgeMap[recombID].length; i++) {
             var destNode = recombEdgeMap[recombID][i];
             var destNodeP = destNode.parent;
 
             destNodeP.removeChild(destNode);
             if (srcNode.isLeftOf(destNodeP)) {
-                destNodeP.children.splice(0,0,destNode);
+                destNodeP.children.splice(0, 0, destNode);
             } else {
                 destNodeP.children.push(destNode);
             }
@@ -223,9 +223,9 @@ Tree.prototype.minimizeHybridSeparation = function() {
 };
 
 // Collapse zero-length edges:
-Tree.prototype.collapseZeroLengthEdges = function() {
+Tree.prototype.collapseZeroLengthEdges = function () {
 
-    this.root.applyPreOrder(function(node) {
+    this.root.applyPreOrder(function (node) {
 
         var childrenToConsider = node.children.slice();
         while (childrenToConsider.length > 0) {
@@ -238,7 +238,7 @@ Tree.prototype.collapseZeroLengthEdges = function() {
                 node.annotation = child.annotation;
                 node.label = child.label;
 
-                for (var j=0; j<child.children.length; j++) {
+                for (var j = 0; j < child.children.length; j++) {
                     var grandChild = child.children[j];
                     node.addChild(grandChild);
                     childrenToConsider.push(grandChild);
@@ -253,7 +253,7 @@ Tree.prototype.collapseZeroLengthEdges = function() {
 };
 
 // Re-root tree:
-Tree.prototype.reroot = function(edgeBaseNode) {
+Tree.prototype.reroot = function (edgeBaseNode) {
 
     this.recombEdgeMap = undefined;
     var currentRecombEdgeMap = this.getRecombEdgeMap();
@@ -324,14 +324,14 @@ Tree.prototype.reroot = function(edgeBaseNode) {
             var destNodePs = [];
 
             destNodes = currentRecombEdgeMap[node.hybridID].slice(1);
-            destNodePs = destNodes.map(function(destNode) {
+            destNodePs = destNodes.map(function (destNode) {
                 return destNode.parent;
             });
 
             // Node will no longer be hybrid
             node.hybridID = undefined;
 
-            for (var i=0; i<destNodes.length; i++) {
+            for (var i = 0; i < destNodes.length; i++) {
                 destNodePs[i].removeChild(destNodes[i]);
 
                 recurseReroot(destNodePs[i], node, seenNodes, destNodes[i].branchLength);
@@ -366,7 +366,7 @@ Tree.prototype.reroot = function(edgeBaseNode) {
     // Ensure destNode leaf heights match those of corresponding srcNodes
     for (recombID in this.getRecombEdgeMap()) {
         var srcNode = this.getRecombEdgeMap()[recombID][0];
-        for (i=1; i<this.getRecombEdgeMap()[recombID].length; i++) {
+        for (i = 1; i < this.getRecombEdgeMap()[recombID].length; i++) {
             var destNode = this.getRecombEdgeMap()[recombID][i];
             destNode.branchLength += destNode.height - srcNode.height;
         }
@@ -375,15 +375,15 @@ Tree.prototype.reroot = function(edgeBaseNode) {
 
 // Retrieve list of traits defined on tree.  Optional filter function can
 // be used to disregard traits defined on a particular subset of nodes.
-Tree.prototype.getTraitList = function(filter) {
+Tree.prototype.getTraitList = function (filter) {
     if (this.root === undefined)
         return [];
 
     var trait; // Define iteration variable
 
     var traitSet = {};
-    for (var i=0; i<this.getNodeList().length; i++) {
-        var thisNode = this.getNodeList()[i];
+    for (var i = 0; i < this.nodeList().length; i++) {
+        var thisNode = this.nodeList()[i];
         for (trait in thisNode.annotation) {
             if (filter !== undefined && !filter(thisNode, trait))
                 continue;
@@ -401,26 +401,26 @@ Tree.prototype.getTraitList = function(filter) {
 
 
 // Return deep copy of tree:
-Tree.prototype.copy = function() {
+Tree.prototype.copy = function () {
     return new Tree(this.root.copy());
 };
 
 
 // Translate labels using provided map:
-Tree.prototype.translate = function(tmap) {
+Tree.prototype.translate = function (tmap) {
 
-    var nodeList = this.getNodeList();
-    for (var i=0; i<nodeList.length; i++) {
+    var nodeList = this.nodeList();
+    for (var i = 0; i < nodeList.length; i++) {
         if (tmap.hasOwnProperty(nodeList[i].label))
             nodeList[i].label = tmap[nodeList[i].label];
     }
 };
 
 // Get total length of all edges in tree
-Tree.prototype.getLength = function() {
+Tree.prototype.getLength = function () {
     var totalLength = 0.0;
-    for (var i=0; i<this.getNodeList().length; i++) {
-        var node = this.getNodeList()[i];
+    for (var i = 0; i < this.nodeList().length; i++) {
+        var node = this.nodeList()[i];
         if (node.isRoot())
             continue;
         totalLength += node.parent.height - node.height;
@@ -431,24 +431,24 @@ Tree.prototype.getLength = function() {
 
 // Return list of nodes belonging to monophyletic groups involving
 // the provided node list
-Tree.prototype.getCladeNodes = function(nodes) {
+Tree.prototype.getCladeNodes = function (nodes) {
 
     function getCladeMembers(node, nodes) {
 
         var cladeMembers = [];
 
         var allChildrenAreMembers = true;
-        for (var cidx=0; cidx<node.children.length; cidx++) {
+        for (var cidx = 0; cidx < node.children.length; cidx++) {
             var child = node.children[cidx];
 
             var childCladeMembers = getCladeMembers(child, nodes);
-            if (childCladeMembers.indexOf(child)<0)
+            if (childCladeMembers.indexOf(child) < 0)
                 allChildrenAreMembers = false;
 
             cladeMembers = cladeMembers.concat(childCladeMembers);
         }
 
-        if (nodes.indexOf(node)>=0 || (node.children.length>0 && allChildrenAreMembers))
+        if (nodes.indexOf(node) >= 0 || (node.children.length > 0 && allChildrenAreMembers))
             cladeMembers = cladeMembers.concat(node);
 
         return cladeMembers;
@@ -458,18 +458,18 @@ Tree.prototype.getCladeNodes = function(nodes) {
 };
 
 // Return list of all nodes ancestral to those in the provided node list
-Tree.prototype.getAncestralNodes = function(nodes) {
+Tree.prototype.getAncestralNodes = function (nodes) {
 
     function getAncestors(node, nodes) {
         var ancestors = [];
 
-        for (var cidx=0; cidx<node.children.length; cidx++) {
+        for (var cidx = 0; cidx < node.children.length; cidx++) {
             var child = node.children[cidx];
 
             ancestors = ancestors.concat(getAncestors(child, nodes));
         }
 
-        if (nodes.indexOf(node)>=0 || ancestors.length>0)
+        if (nodes.indexOf(node) >= 0 || ancestors.length > 0)
             ancestors = ancestors.concat(node);
 
         return ancestors;
@@ -478,22 +478,22 @@ Tree.prototype.getAncestralNodes = function(nodes) {
     return getAncestors(this.root, nodes);
 };
 
-Tree.prototype.getLineagesThroughTime = function() {
-    var nodeList = this.getNodeList().slice(0);
+Tree.prototype.getLineagesThroughTime = function () {
+    var nodeList = this.nodeList().slice(0);
 
-    nodeList.sort(function(nodeA, nodeB) {return nodeA.height - nodeB.height})
+    nodeList.sort(function (nodeA, nodeB) { return nodeA.height - nodeB.height })
 
-    res = {lineages: [], ages: []};
+    res = { lineages: [], ages: [] };
 
     var k = 0;
-    for (var i=0; i<nodeList.length; i++) {
-	var node = nodeList[i];
+    for (var i = 0; i < nodeList.length; i++) {
+        var node = nodeList[i];
 
-	k += 1 - node.children.length;
+        k += 1 - node.children.length;
 
-	res.lineages.push(k);
-	res.ages.push(node.height);
+        res.lineages.push(k);
+        res.ages.push(node.height);
     }
 
-    return(res);
+    return (res);
 }

--- a/js/Tree.js
+++ b/js/Tree.js
@@ -27,15 +27,15 @@ Tree.prototype.computeNodeAges = function () {
 
     this.isTimeTree = !Number.isNaN(youngestHeight) && (heights.length > 1 || this.root.branchLength !== undefined);
 
-    for (var i = 0; i < this.nodeList().length; i++)
-        this.nodeList()[i].height -= youngestHeight;
+    for (var i = 0; i < this.nodeList.length; i++)
+        this.nodeList[i].height -= youngestHeight;
 };
 
 // Assign new node IDs (use with care!)
 Tree.prototype.reassignNodeIDs = function () {
     var nodeID = 0;
-    for (var i = 0; i < this.nodeList().length; i++)
-        this.nodeList()[i].id = nodeID++;
+    for (var i = 0; i < this.nodeList.length; i++)
+        this.nodeList[i].id = nodeID++;
 };
 
 // Clear various node caches:
@@ -62,8 +62,8 @@ Tree.prototype.getNodeList = function () {
 Tree.prototype.getNode = function (nodeID) {
     if (this.nodeIDMap === undefined && this.root !== undefined) {
         this.nodeIDMap = {};
-        for (var i = 0; i < this.nodeList().length; i++) {
-            var node = this.nodeList()[i];
+        for (var i = 0; i < this.nodeList.length; i++) {
+            var node = this.nodeList[i];
             this.nodeIDMap[node] = node;
         }
     }
@@ -382,8 +382,8 @@ Tree.prototype.getTraitList = function (filter) {
     var trait; // Define iteration variable
 
     var traitSet = {};
-    for (var i = 0; i < this.nodeList().length; i++) {
-        var thisNode = this.nodeList()[i];
+    for (var i = 0; i < this.nodeList.length; i++) {
+        var thisNode = this.nodeList[i];
         for (trait in thisNode.annotation) {
             if (filter !== undefined && !filter(thisNode, trait))
                 continue;
@@ -409,7 +409,7 @@ Tree.prototype.copy = function () {
 // Translate labels using provided map:
 Tree.prototype.translate = function (tmap) {
 
-    var nodeList = this.nodeList();
+    var nodeList = this.nodeList;
     for (var i = 0; i < nodeList.length; i++) {
         if (tmap.hasOwnProperty(nodeList[i].label))
             nodeList[i].label = tmap[nodeList[i].label];
@@ -419,8 +419,8 @@ Tree.prototype.translate = function (tmap) {
 // Get total length of all edges in tree
 Tree.prototype.getLength = function () {
     var totalLength = 0.0;
-    for (var i = 0; i < this.nodeList().length; i++) {
-        var node = this.nodeList()[i];
+    for (var i = 0; i < this.nodeList.length; i++) {
+        var node = this.nodeList[i];
         if (node.isRoot())
             continue;
         totalLength += node.parent.height - node.height;
@@ -479,7 +479,7 @@ Tree.prototype.getAncestralNodes = function (nodes) {
 };
 
 Tree.prototype.getLineagesThroughTime = function () {
-    var nodeList = this.nodeList().slice(0);
+    var nodeList = this.nodeList.slice(0);
 
     nodeList.sort(function (nodeA, nodeB) { return nodeA.height - nodeB.height })
 

--- a/js/Writer.js
+++ b/js/Writer.js
@@ -29,8 +29,8 @@ var Write = (function () {
         var res = "";
         if (!node.isLeaf()) {
             res += "(";
-            for (var i=0; i<node.children.length; i++) {
-                if (i>0)
+            for (var i = 0; i < node.children.length; i++) {
+                if (i > 0)
                     res += ",";
                 res += newickRecurse(node.children[i], annotate);
             }
@@ -45,12 +45,12 @@ var Write = (function () {
 
         if (annotate) {
             var keys = Object.keys(node.annotation);
-            if (keys.length>0) {
+            if (keys.length > 0) {
                 res += "[&";
-                for (var idx=0; idx<keys.length; idx++) {
+                for (var idx = 0; idx < keys.length; idx++) {
                     var key = keys[idx];
 
-                    if (idx>0)
+                    if (idx > 0)
                         res += ",";
                     res += "\"" + key + "\"=";
                     if (node.annotation[key] instanceof Array)
@@ -115,7 +115,7 @@ var Write = (function () {
         if (node.branchLength !== undefined)
             clade.setAttribute("branch_length", node.branchLength);
 
-        for (var i=0; i<node.children.length; i++)
+        for (var i = 0; i < node.children.length; i++)
             clade.appendChild(phyloXMLRecurse(node.children[i], doc));
 
         return clade;
@@ -152,7 +152,7 @@ var Write = (function () {
         if (node.label !== undefined && node.label !== "")
             nodeEl.setAttribute("label", node.label);
 
-        if (Object.keys(node.annotation).length>0) {
+        if (Object.keys(node.annotation).length > 0) {
             nodeEl.setAttribute("about", "#n" + node.id);
 
             var metaID = 0;
@@ -171,7 +171,7 @@ var Write = (function () {
 
         treeEl.appendChild(nodeEl);
 
-        for (var i=0; i<node.children.length; i++) {
+        for (var i = 0; i < node.children.length; i++) {
             var child = node.children[i];
 
 
@@ -185,7 +185,7 @@ var Write = (function () {
                 edgeEl.setAttribute("length", child.branchLength);
 
             treeEl.appendChild(edgeEl);
-            
+
             neXMLRecurse(child, doc, treeEl);
         }
 
@@ -203,9 +203,9 @@ var Write = (function () {
             var otus = doc.createElementNS(neXMLNS, "otus");
             otus.setAttribute("id", "taxa");
             otus.setAttribute("label", "RootTaxaBlock");
-            for (var i=0; i<tree.getLeafList().length; i++) {
+            for (var i = 0; i < tree.leafList().length; i++) {
                 var otu = doc.createElementNS(neXMLNS, "otu");
-                otu.setAttribute("id", "t" + tree.getLeafList()[i].id);
+                otu.setAttribute("id", "t" + tree.leafList()[i].id);
                 otus.appendChild(otu);
             }
             doc.documentElement.appendChild(otus);
@@ -231,4 +231,4 @@ var Write = (function () {
         phyloXML: phyloXMLWriter,
         neXML: neXMLWriter
     };
-}) ();
+})();

--- a/js/Writer.js
+++ b/js/Writer.js
@@ -203,9 +203,9 @@ var Write = (function () {
             var otus = doc.createElementNS(neXMLNS, "otus");
             otus.setAttribute("id", "taxa");
             otus.setAttribute("label", "RootTaxaBlock");
-            for (var i = 0; i < tree.leafList().length; i++) {
+            for (var i = 0; i < tree.leafList.length; i++) {
                 var otu = doc.createElementNS(neXMLNS, "otu");
-                otu.setAttribute("id", "t" + tree.leafList()[i].id);
+                otu.setAttribute("id", "t" + tree.leafList[i].id);
                 otus.appendChild(otu);
             }
             doc.documentElement.appendChild(otus);

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -5,13 +5,13 @@ export class Tree {
   /** Public property used to construct tree */
   root: Node;
   /** A public property */
-  nodeList: Node[] | undefined;
+  private _nodeList: Node[] | undefined;
   /** A public property */
   nodeIDMap: { [key: number]: Node } | undefined;
   /** A public property */
   labelNodeMap: { [key: string]: Node } | undefined;
   /** A public property */
-  leafList: Node[] | undefined;
+  private _leafList: Node[] | undefined;
   /** A public property */
   recombEdgeMap: { [key: string]: Node[] } | undefined;
   /** A protected property */
@@ -50,8 +50,8 @@ export class Tree {
       !Number.isNaN(youngestHeight) &&
       (heights.length > 1 || this.root.branchLength !== undefined);
 
-    for (let i = 0; i < this.getNodeList().length; i++) {
-      const node = this.getNodeList()[i];
+    for (let i = 0; i < this.nodeList.length; i++) {
+      const node = this.nodeList[i];
       if (node.height !== undefined) {
         node.height -= youngestHeight;
       }
@@ -77,9 +77,9 @@ export class Tree {
     });
   }
 
-  /** Return branch lengths in order matching .getNodeList() */
+  /** Return branch lengths in order matching .nodeList */
   getBranchLengths(): (number | undefined)[] {
-    return this.getNodeList().map(e => e.branchLength);
+    return this.nodeList.map(e => e.branchLength);
   }
 
   /** Returns root to tip distances. Counts undefined branch lengths as zero */
@@ -104,30 +104,30 @@ export class Tree {
   /** Assign new node IDs (use with care!) */
   reassignNodeIDs(): void {
     let nodeID = 0;
-    for (let i = 0; i < this.getNodeList().length; i++)
-      this.getNodeList()[i].id = nodeID++;
+    for (let i = 0; i < this.nodeList.length; i++)
+      this.nodeList[i].id = nodeID++;
   }
 
   /** Clear various node caches */
   clearCaches(): void {
-    this.nodeList = undefined;
+    this._nodeList = undefined;
     this.nodeIDMap = undefined;
     this.labelNodeMap = undefined;
-    this.leafList = undefined;
+    this._leafList = undefined;
     this.recombEdgeMap = undefined;
   }
 
-  /** Retrieve list of nodes in tree. */
-  getNodeList(): Node[] {
-    if (this.nodeList === undefined && this.root !== undefined) {
-      this.nodeList = this.root.applyPreOrder((node: Node) => {
+  /** A getter that returns an array of nodes (`Node[]`) from private `_nodeList` property in order determined by a pre-order search*/
+  get nodeList(): Node[] {
+    if (this._nodeList === undefined && this.root !== undefined) {
+      this._nodeList = this.root.applyPreOrder((node: Node) => {
         return node;
       });
     }
-    if (!this.nodeList) {
+    if (!this._nodeList) {
       return [];
     }
-    return this.nodeList;
+    return this._nodeList;
   }
 
   /**
@@ -137,23 +137,23 @@ export class Tree {
   getNode(nodeID: number): Node | null {
     if (this.nodeIDMap === undefined && this.root !== undefined) {
       this.nodeIDMap = {};
-      for (let i = 0; i < this.getNodeList().length; i++) {
-        const node: Node = this.getNodeList()[i];
+      for (let i = 0; i < this.nodeList.length; i++) {
+        const node: Node = this.nodeList[i];
         this.nodeIDMap[node.id] = node;
       }
     }
     return this.nodeIDMap == undefined ? null : this.nodeIDMap[nodeID];
   }
 
-  /** Retrieve list of leaves in tree. Order determined by pre-order search */
-  getLeafList(): Node[] {
-    if (this.leafList === undefined && this.root !== undefined) {
-      this.leafList = this.root.applyPreOrder((node: Node) => {
+  /** A getter that returns an array of nodes (`Node[]`) from private `_nodeList` property in order determined by a pre-order search*/
+  get leafList(): Node[] {
+    if (this._leafList === undefined && this.root !== undefined) {
+      this._leafList = this.root.applyPreOrder((node: Node) => {
         if (node.isLeaf()) return node;
         else return null;
       });
     }
-    return this.leafList == undefined ? [] : this.leafList;
+    return this._leafList == undefined ? [] : this._leafList;
   }
 
   /**
@@ -163,8 +163,8 @@ export class Tree {
   getNodeByLabel(label: string): Node | null {
     if (this.labelNodeMap === undefined && this.root !== undefined) {
       this.labelNodeMap = {};
-      for (let i = 0; i < this.getLeafList().length; i++) {
-        const node: Node = this.getLeafList()[i];
+      for (let i = 0; i < this.leafList.length; i++) {
+        const node: Node = this.leafList[i];
         if (node.label !== undefined) {
           this.labelNodeMap[node.label] = node; // Assume Node has 'label' property
         }
@@ -278,10 +278,10 @@ export class Tree {
     let tips: string[];
     if (node !== undefined) {
       tips = this.getSubtree(node)
-        .getLeafList()
+        .leafList
         .map(e => e.label ?? e.id.toString());
     } else {
-      tips = this.getLeafList().map(e => e.label ?? e.id.toString());
+      tips = this.leafList.map(e => e.label ?? e.id.toString());
     }
     return tips;
   }
@@ -289,7 +289,7 @@ export class Tree {
   /** Sum of all defined branch lengths. Elsewhere referred to tree "length" if all baranch lengths are defined */
   getTotalBranchLength(): number {
     let totalLength = 0.0;
-    const nodeList = this.getNodeList();
+    const nodeList = this.nodeList;
 
     for (const node of nodeList) {
       if (node.branchLength !== undefined) {

--- a/test/tree/tree.spec.ts
+++ b/test/tree/tree.spec.ts
@@ -28,7 +28,7 @@ describe('Tree', () => {
   test('reroot', () => {
     expect(
       tree
-        .nodeList()
+        .nodeList
         .map(n => n.label)
         .filter(n => n !== undefined)
     ).toStrictEqual(['A', 'B', 'C']);
@@ -38,7 +38,7 @@ describe('Tree', () => {
     expect(tree.root.children.length).toBe(2);
     expect(
       tree
-        .nodeList()
+        .nodeList
         .map(n => n.label)
         .filter(n => n !== undefined)
     ).toStrictEqual(['C', 'B', 'A']);
@@ -48,7 +48,7 @@ describe('Tree', () => {
 describe('reroot() - basic', () => {
   test('updates nwk', () => {
     const tr = readNewick('((A:1,B:1):1,C:1);');
-    tr.reroot(tr.nodeList()[3]);
+    tr.reroot(tr.nodeList[3]);
     const nwkPrime = writeNewick(tr);
 
     expect(nwkPrime).not.toBe('((A:1,B:1):1,C:1);');
@@ -66,7 +66,7 @@ describe('reroot() - basic', () => {
     const tol = 1e-10; // smaller than smallest branch length here
 
     for (let i = 0; i < tr.length; i++) {
-      nodes = tr[i].nodeList().slice(1); // exclude root (0th id)
+      nodes = tr[i].nodeList.slice(1); // exclude root (0th id)
       for (let j = 0; j < nodes.length; j++) {
         originalLength.push(tr[i].getTotalBranchLength());
 
@@ -125,7 +125,7 @@ describe('getRTTDist()', () => {
 describe('getSubtree()', () => {
   test('simple tree', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const subTree = tr.getSubtree(tr.nodeList()[1]);
+    const subTree = tr.getSubtree(tr.nodeList[1]);
 
     expect(writeNewick(subTree)).toBe(
       '((("A":0.0,"B":0.0):0.0,"C":0.0):0.0,"D":0.0):0.0;'
@@ -136,7 +136,7 @@ describe('getSubtree()', () => {
 describe('getMRCA()', () => {
   test('same node', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.leafList()[0];
+    const nodeA = tr.leafList[0];
     const mrca = tr.getMRCA([nodeA, nodeA]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -145,8 +145,8 @@ describe('getMRCA()', () => {
 
   test('sibling nodes', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.leafList()[0];
-    const nodeB = tr.leafList()[1];
+    const nodeA = tr.leafList[0];
+    const nodeB = tr.leafList[1];
     const mrca = tr.getMRCA([nodeA, nodeB]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -155,8 +155,8 @@ describe('getMRCA()', () => {
 
   test('non-sibling nodes', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.leafList()[0];
-    const nodeC = tr.leafList()[2];
+    const nodeA = tr.leafList[0];
+    const nodeC = tr.leafList[2];
     const mrca = tr.getMRCA([nodeA, nodeC]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -204,7 +204,7 @@ describe('getTipLabels()', () => {
   });
 
   test('subtree', () => {
-    const labs = tr.getSubtree(tr.nodeList()[1]).getTipLabels();
+    const labs = tr.getSubtree(tr.nodeList[1]).getTipLabels();
 
     expect(JSON.stringify(labs)).toMatch(JSON.stringify(['A', 'B', 'C', 'D']));
   });

--- a/test/tree/tree.spec.ts
+++ b/test/tree/tree.spec.ts
@@ -28,7 +28,7 @@ describe('Tree', () => {
   test('reroot', () => {
     expect(
       tree
-        .getNodeList()
+        .nodeList()
         .map(n => n.label)
         .filter(n => n !== undefined)
     ).toStrictEqual(['A', 'B', 'C']);
@@ -38,7 +38,7 @@ describe('Tree', () => {
     expect(tree.root.children.length).toBe(2);
     expect(
       tree
-        .getNodeList()
+        .nodeList()
         .map(n => n.label)
         .filter(n => n !== undefined)
     ).toStrictEqual(['C', 'B', 'A']);
@@ -48,7 +48,7 @@ describe('Tree', () => {
 describe('reroot() - basic', () => {
   test('updates nwk', () => {
     const tr = readNewick('((A:1,B:1):1,C:1);');
-    tr.reroot(tr.getNodeList()[3]);
+    tr.reroot(tr.nodeList()[3]);
     const nwkPrime = writeNewick(tr);
 
     expect(nwkPrime).not.toBe('((A:1,B:1):1,C:1);');
@@ -66,7 +66,7 @@ describe('reroot() - basic', () => {
     const tol = 1e-10; // smaller than smallest branch length here
 
     for (let i = 0; i < tr.length; i++) {
-      nodes = tr[i].getNodeList().slice(1); // exclude root (0th id)
+      nodes = tr[i].nodeList().slice(1); // exclude root (0th id)
       for (let j = 0; j < nodes.length; j++) {
         originalLength.push(tr[i].getTotalBranchLength());
 
@@ -125,7 +125,7 @@ describe('getRTTDist()', () => {
 describe('getSubtree()', () => {
   test('simple tree', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const subTree = tr.getSubtree(tr.getNodeList()[1]);
+    const subTree = tr.getSubtree(tr.nodeList()[1]);
 
     expect(writeNewick(subTree)).toBe(
       '((("A":0.0,"B":0.0):0.0,"C":0.0):0.0,"D":0.0):0.0;'
@@ -136,7 +136,7 @@ describe('getSubtree()', () => {
 describe('getMRCA()', () => {
   test('same node', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.getLeafList()[0];
+    const nodeA = tr.leafList()[0];
     const mrca = tr.getMRCA([nodeA, nodeA]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -145,8 +145,8 @@ describe('getMRCA()', () => {
 
   test('sibling nodes', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.getLeafList()[0];
-    const nodeB = tr.getLeafList()[1];
+    const nodeA = tr.leafList()[0];
+    const nodeB = tr.leafList()[1];
     const mrca = tr.getMRCA([nodeA, nodeB]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -155,8 +155,8 @@ describe('getMRCA()', () => {
 
   test('non-sibling nodes', () => {
     const tr = readNewick('((((A,B),C),D),E);');
-    const nodeA = tr.getLeafList()[0];
-    const nodeC = tr.getLeafList()[2];
+    const nodeA = tr.leafList()[0];
+    const nodeC = tr.leafList()[2];
     const mrca = tr.getMRCA([nodeA, nodeC]);
     if (mrca === null) throw new Error('MRCA is null');
     const subTree = tr.getSubtree(mrca);
@@ -204,7 +204,7 @@ describe('getTipLabels()', () => {
   });
 
   test('subtree', () => {
-    const labs = tr.getSubtree(tr.getNodeList()[1]).getTipLabels();
+    const labs = tr.getSubtree(tr.nodeList()[1]).getTipLabels();
 
     expect(JSON.stringify(labs)).toMatch(JSON.stringify(['A', 'B', 'C', 'D']));
   });


### PR DESCRIPTION
Added getters: `nodeList` and `leafList` on tree object. They return type `Node[]` in order of a post-order search of the new private properties ` _nodeList` and `_leafList`.