### PR TITLE
Small typo fix and edit URI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@
 site_name: phylojs
 site_url: https://clockor2.github.io/phylojs/
 repo_url: https://github.com/clockor2/phylojs
+edit_uri: https://github.com/clockor2/phylojs/edit/main/docs/
 
 theme:
   name: "material"
@@ -54,7 +55,7 @@ nav:
     - examples/index.md
     - Overview of the Tree Class: examples/tree.md
     - Visualise: examples/visualise.md
-    - Fetching Trees fron a URL: examples/fetch.md
+    - Fetching Trees from a URL: examples/fetch.md
     - Finding the MRCA: examples/mrca.md
     - Root-to-tip regression: examples/rttr.md
     - Rerooting: examples/reroot.md


### PR DESCRIPTION
### Description of change
(Congrats on phylojs!)
I noticed a small typo in the docs. I also noticed that when I tried to fix it the edit button in the docs didn't work, which is because MkDocs defaults to edit `master`, but the main branch here is `main`. From reading https://www.mkdocs.org/user-guide/configuration/ I expect this configuration to fix the edit button, but I have not tested this and could have made a mistake. Feel free to close this and treat it as an issue instead.