### PR TITLE
fix: Read tree bug #58

### DIFF
--- a/test/io/readers.spec.ts
+++ b/test/io/readers.spec.ts
@@ -22,7 +22,7 @@ describe('read', () => {
         const inNewick = readFileSync('test/data/egTree.nwk', 'utf-8');
         const tree = readNewick(inNewick);
         // test the number of nodes
-        expect(tree.nodeList.length).toBe(274);
+        expect(tree.leafList.length).toBe(274);
     });
 });
 

--- a/test/io/readers.spec.ts
+++ b/test/io/readers.spec.ts
@@ -16,6 +16,17 @@ import { parseNewickAnnotations, parseHybridLabels } from '../../src/io/readers/
 import { readFileSync } from 'fs';
 import { beastAnnotation, nhxAnnotation } from '../../src/io/writers/newick';
 
+// test read local files
+describe('read', () => {
+    test('readNewick', () => {
+        const inNewick = readFileSync('test/data/egTree.nwk', 'utf-8');
+        const tree = readNewick(inNewick);
+        // test the number of nodes
+        expect(tree.nodeList.length).toBe(274);
+    });
+});
+
+
 describe('parseAnnotations', () => {
     test('parseBEASTStyleAnnotations', () => {
         var a = '&col=Red,hand={left,right}';

--- a/test/io/readers.spec.ts
+++ b/test/io/readers.spec.ts
@@ -18,11 +18,15 @@ import { beastAnnotation, nhxAnnotation } from '../../src/io/writers/newick';
 
 // test read local files
 describe('read', () => {
-    test('readNewick', () => {
+    test('readTreesFromNewick', () => {
+
         const inNewick = readFileSync('test/data/egTree.nwk', 'utf-8');
-        const tree = readNewick(inNewick);
-        // test the number of nodes
+
+        const tree = readTreesFromNewick(inNewick)[0];
+
+        // test the number of leaves
         expect(tree.leafList.length).toBe(274);
+
     });
 });
 


### PR DESCRIPTION
Issue was using `readNewick` where the input file had multiple trees in it. Changed to `readTreesFromNewick()` and selected 0th tree to match the MERS example.