### PR TITLE
feat(tests): :bug: enable coverage reporting for Jest tests #80

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
   moduleNameMapper: pathsToModuleNameMapper(paths, {
     prefix: '<rootDir>/',
   }),
+  collectCoverage: true, // Enable coverage collection
+  coverageProvider: 'v8', // Use the V8 coverage engine
   collectCoverageFrom: [
     '<rootDir>/src/**/*.ts',
     '!<rootDir>/src/types/**/*.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5861,6 +5861,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky install",
     "semantic-release": "semantic-release",
     "test:watch": "jest --watch",
-    "test": "jest",
+    "test": "jest --coverage",
     "typecheck": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
Use v8 engine for test coverage in jest, this avoids the heap error whose source was otherwise unclear.