### PR TITLE
feat(tree): :goal_net: throw error if rerooting network #82

### DIFF
--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -360,6 +360,11 @@ export class Tree {
    * @param {number|undefined} prop Proportion of the branch descending from `edgeBaseNode` at which to cut and place the root. Defaults ot 0.5
    */
   reroot(edgeBaseNode: Node, prop = 0.5): void {
+    // --- Prior check if nework ---
+    if (this.isNetwork()) {
+      throw new Error('Cannot reroot a network.');
+    }
+
     // --- 0. Prep old root and recomb map ---
     const oldRoot = this.root;
     this.recombEdgeMap = undefined;

--- a/test/tree/tree.spec.ts
+++ b/test/tree/tree.spec.ts
@@ -110,6 +110,16 @@ describe('reroot() - basic', () => {
         expect(JSON.stringify(diff)).toBe(
             JSON.stringify(originalLength.map(e => true))
         );
+    });
+
+    test('Expect error if rerooting network', () => {
+        const inNHX = readFileSync('test/data/ARG.newick', 'utf-8').split("\n")[0];
+        const network = readNewick(inNHX);
+        const node = network.nodeList[network.nodeList.length - 1]
+        expect(() => {
+            network.reroot(node)
+        }
+        ).toThrowError('Cannot reroot a network');
     })
 });
 


### PR DESCRIPTION
Temporary prevention: Throw an error if attempting to reroot a network

This is an extremely rare use case. While desirable, I can't prioritise fixing it right away, so we will throw an error for now