### PR TITLE
Parse custom annotations

### DIFF
--- a/docs/examples/annotations.md
+++ b/docs/examples/annotations.md
@@ -4,7 +4,7 @@ This is another example, in addition to "Annotations and Pre-Order Traversal", t
 
 Here, we show show how annotations can be extracted and modified in a loop. We swap Blue an Green type annotations to Red and Yellow on a small tree.
 
-All node objects have an `annotation` field where annotations. The `annotation` fiel itself stores an object for all annotated tags. For example `Node.annotations = {Type: Blue}` for some leaf nodes in the following example.
+All node objects have an `annotation` field where annotations. The `annotation` field itself stores an object for all annotated tags. For example `Node.annotations = {Type: Blue}` for some leaf nodes in the following example.
 
 Altered annotations are then written back to newick.
 

--- a/docs/examples/customAnnotationParsingAndWriting.md
+++ b/docs/examples/customAnnotationParsingAndWriting.md
@@ -1,0 +1,17 @@
+# How to use custom annotation parsers and writer with readNewick and writeNewick
+
+PhyloJS provides flexibility in handling custom annotations in Newick format trees through custom parser and writer functions. This example demonstrates how to read a Newick string with custom annotations and write it back with custom formatting.
+
+Let's say we have a Newick tree with some custom annotation format with key value pairs separated by ';'. This is a terrible idea in practice because ';' signifies the end of a 
+Newick string, but for the sake of an example, let's run with it.
+
+NOTE: As of 17-05-2025, custom parsers still expect annotations to be enclosed in square brackets. This is a limitation of the current implementation and will be fixed in future releases.
+
+```javascript
+
+<p class="codepen" data-height="300" data-default-tab="html,result" data-slug-hash="ByyEjNW" data-pen-title="Custom Annotation Parsing and Writing" data-user="LeoFeatherstone" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+  <span>See the Pen <a href="https://codepen.io/LeoFeatherstone/pen/ByyEjNW">
+  Custom Annotation Parsing and Writing</a> by Leo Featherstone (<a href="https://codepen.io/LeoFeatherstone">@LeoFeatherstone</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://public.codepenassets.com/embed/index.js"></script>

--- a/docs/reader.md
+++ b/docs/reader.md
@@ -8,8 +8,13 @@ This function reads a NeXML string and returns a single tree. NeXML is an XML fo
 Reads NeXML strings and returns an array of trees, allowing multiple trees to be parsed from a single NeXML document.
 
 ## Newick
-`readNewick(str: string): Tree`
-Parses a Newick format string and returns a tree.
+```javascript
+readNewick(
+    str: string,
+    annotationParser: (annotations: string) => typeof Node.prototype.annotation = parseNewickAnnotations
+    ): Tree
+```
+Parses a Newick format string and returns a tree. See API for details on the `annotationParser` function. In short, it is optional and you can ommit any reference to it if you do not need to parse annotations. That is, you can just call `readNewick(str)`.
 
 `readTreesFromNewick(newick: string): Tree[]`
 Reads multiple Newick format strings, each separated by `\n`, and returns an array of trees.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Pruning and Grafting: examples/pruneGraft.md
       - Extracting Clades: examples/mrca.md
       - Modifying Annotations: examples/annotations.md
+      - Custom annotation parsing and writing: examples/customAnnotationParsingAndWriting.md
       - Arrays of Trees: examples/treeArray.md
   - API: "typedoc"
   - Cite: cite.md

--- a/src/io/readers/newick.ts
+++ b/src/io/readers/newick.ts
@@ -186,12 +186,13 @@ function kn_add_node(
   ) {
     const c = str.charAt(i);
     if (c == '[') {
+      // TODO: Custom open delimiter?
       const meta_beg = i;
       if (end == 0) end = i;
       do ++i;
       while (i < str.length && str.charAt(i) != ']');
       if (i == str.length) {
-        //tree.error |= 4; // <-- TODO: add unfinished annotation error
+        throw new Error('Unclosed annotation bracket in Newick string');
         break;
       }
       z.annotation = annotationParser(str.slice(meta_beg + 1, i));
@@ -269,7 +270,23 @@ export function parseHybridLabels(label: string): HybridInformation {
 }
 
 /**
- * Type definition for annotation parsers
+ * Users can provide theit own annotation parsers.
+ *
+ * Note that square brackets are hard-coded in readNewick() as open and close
+ * delimiters for annotations. This is a limitation, but as far as we know, all
+ * annotations in Newick format are enclosed in square brackets.
+ *
+ * In the future, we may want to add support for custom open and close
+ * delimiters, but this would require a more complex parsing logic.
+ *
+ * In the complementary function custon annotation writers, users can define their own
+ * open and close delimiters.
+ *
+ * @typedef {function} annotationParser
+ * @param {string} annotations - The string containing annotations in Newick format
+ * @returns {typeof Node.prototype.annotation} - The parsed annotations as key value pairs
+ * @property {string} [key] - The key of the annotation
+ * @property {any} [value] - The value of the annotation
  */
 export type AnnotationParser = (
   annotations: string
@@ -279,8 +296,10 @@ export type AnnotationParser = (
  * Parses BEAST-type annotations in format [&...] to object for storage
  * in `Node` object. Annotations in arrays are expected to be stored in braces,
  * and separated by ',' or ':'. For example ...Type={Blue,Red} or ...Type={Blue:Red}
- * @param {string} annotations
- * @returns {any}
+ * @param {string} annotations - The string containing annotations in Newick format
+ * @returns {typeof Node.prototype.annotation} - The parsed annotations as key value pairs
+ * @property {string} [key] - The key of the annotation
+ * @property {any} [value] - The value of the annotation
  */
 export function parseBeastAnnotations(
   annotations: string
@@ -313,8 +332,10 @@ export function parseBeastAnnotations(
 /**
  * Parses NHX-type annotations in format [&&NHX:...] to object for storage
  * in `Node` object. Annotations in arrays are expected to be stored in braces.
- * @param {string} annotations
- * @returns {any}
+ * @param {string} annotations - The string containing annotations in Newick format
+ * @returns {typeof Node.prototype.annotation} - The parsed annotations as key value pairs
+ * @property {string} [key] - The key of the annotation
+ * @property {any} [value] - The value of the annotation
  */
 export function parseNHXAnnotations(
   annotations: string
@@ -347,8 +368,10 @@ export function parseNHXAnnotations(
 
 /**
  * Default annotation parser that checks for both BEAST and NHX formats
- * @param {string} annotations
- * @returns {any}
+ * @param {string} annotations - The string containing annotations in Newick format
+ * @returns {typeof Node.prototype.annotation} - The parsed annotations as key value pairs
+ * @property {string} [key] - The key of the annotation
+ * @property {any} [value] - The value of the annotation
  */
 export function parseNewickAnnotations(
   annotations: string

--- a/src/io/readers/nexus.ts
+++ b/src/io/readers/nexus.ts
@@ -95,7 +95,7 @@ function _getTreesFromNexus(nexus: string, singleTree?: boolean): Tree[] {
 }
 
 /**
- * Reads a tree from nexus format.
+ * Reads a tree from nexus format. Currently does not support custom annotation parsing.
  * @param {string} nexus
  * @returns {Tree}
  */

--- a/src/tree/node.ts
+++ b/src/tree/node.ts
@@ -15,7 +15,7 @@ export class Node {
   /** Node label */
   label: string | undefined;
   /** Node annotation(s) */
-  annotation: { [key: string]: string | string[] | null };
+  annotation: { [key: string]: any };
   /** ID of node if hybrid */
   hybridID: number | undefined;
 


### PR DESCRIPTION
#71
#68 

Node annotations can now be of type any custom parsers can be used in `readNewick`