### PR TITLE
Move annotation start/end out of writers

### DIFF
--- a/src/io/writers/newick.ts
+++ b/src/io/writers/newick.ts
@@ -53,9 +53,10 @@ export function newickRecurse(
     res += `#${node.hybridID}`;
   }
   // annotations
-  res += "["
-  res += annotationWriter(node.annotation);
-  res += "]"
+  const annotation = annotationWriter(node.annotation);
+  if (annotation.length !== 0) {
+    res += `[${annotation}]`;
+  }
   // branch lengths
   if (node.branchLength !== undefined) {
     node.branchLength == 0 ? (res += ':0.0') : (res += `:${node.branchLength}`);

--- a/src/io/writers/newick.ts
+++ b/src/io/writers/newick.ts
@@ -52,9 +52,11 @@ export function newickRecurse(
   } else if (node.label == undefined && node.hybridID !== undefined) {
     res += `#${node.hybridID}`;
   }
-
+  // annotations
+  res += "["
   res += annotationWriter(node.annotation);
-
+  res += "]"
+  // branch lengths
   if (node.branchLength !== undefined) {
     node.branchLength == 0 ? (res += ':0.0') : (res += `:${node.branchLength}`);
   }
@@ -77,7 +79,7 @@ export function beastAnnotation(
     const keys = Object.keys(annotation);
 
     if (keys.length > 0) {
-      res += '[&';
+      res += '&';
 
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
@@ -92,8 +94,6 @@ export function beastAnnotation(
           res += `${String(value)}`; // Explicitly convert the value to a string
         }
       }
-
-      res += ']';
     }
   }
 
@@ -116,7 +116,7 @@ export function nhxAnnotation(
     const keys = Object.keys(annotation);
 
     if (keys.length > 0) {
-      res += '[&&NHX:';
+      res += '&&NHX:';
 
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
@@ -127,8 +127,6 @@ export function nhxAnnotation(
         const value = annotation[key];
         res += `${String(value)}`; // Explicitly convert the value to a string
       }
-
-      res += ']';
     }
   }
 

--- a/test/io/readers.spec.ts
+++ b/test/io/readers.spec.ts
@@ -143,7 +143,7 @@ describe('parseAnnotations', () => {
 
         const outputNewick = writeNewick(tree, customAnnotationWriter);
 
-        expect(outputNewick).toBe('(("A"{color:MODIFIED;isRelevant:no},"B"),"C"{color:MODIFIED});')
+        expect(outputNewick).toBe('(("A"[{color:MODIFIED;isRelevant:no}],"B"),"C"[{color:MODIFIED}]);')
 
     })
 })

--- a/test/io/writers.spec.ts
+++ b/test/io/writers.spec.ts
@@ -8,14 +8,14 @@ describe('annotationWriters', () => {
             col: 'Blue',
             hand: ['left', 'right']
         }
-        expect(beastAnnotation(ann)).toBe('[&col=Blue,hand={left,right}]')
+        expect(beastAnnotation(ann)).toBe('&col=Blue,hand={left,right}')
     })
     test('nhxAnnotation', () => {
         let ann = {
             col: 'Blue',
             hand: 'left'
         }
-        expect(nhxAnnotation(ann)).toBe('[&&NHX:col=Blue:hand=left]')
+        expect(nhxAnnotation(ann)).toBe('&&NHX:col=Blue:hand=left')
     })
 })
 


### PR DESCRIPTION
I've moved the annotation start [ and end ] out of the writers so the writers won't break the newick spec. 